### PR TITLE
Initial default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,41 @@
 osl-docker Cookbook
 ===================
-TODO: Enter the cookbook description here.
 
-e.g.
-This cookbook makes your favorite breakfast sandwich.
+OSL wrapper cookbook using
+[docker](https://supermarket.chef.io/cookbooks/docker) as a base. It installs
+the docker package from Docker Inc. and starts the docker service.
 
 Requirements
 ------------
-TODO: List your cookbook requirements. Be sure to include any
-requirements this cookbook has on platforms, libraries, other cookbooks,
-packages, operating systems, etc.
 
-e.g.
-#### packages
-- `toaster` - osl-docker needs toaster to brown your bagel.
+- Chef 12.18.x or higher
 
 Attributes
 ----------
-TODO: List your cookbook attributes here.
 
-e.g.
-#### osl-docker::default
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['osl-docker']['bacon']</tt></td>
-    <td>Boolean</td>
-    <td>whether to include bacon</td>
-    <td><tt>true</tt></td>
-  </tr>
-</table>
+- ``node['osl-docker']['package']`` -- Key/value hash which directly relates to
+  the ``docker_installation_package`` resource.
+- ``node['osl-docker']['service'] `` -- Key/value hash which directly relates to
+  the ``docker_service``.
+
+For example, if you wish to set the package version you could do the following:
+
+``` ruby
+node['osl-docker']['package']['version'] = '1.13.1'
+```
+
+If you wish to have have docker to listen on TCP instead of a socket, you can do
+the following:
+
+``` ruby
+node['osl-docker']['service']['host'] = 'tcp://0.0.0.0:2375'
+```
 
 Usage
 -----
 #### osl-docker::default
-TODO: Write usage instructions for each cookbook.
 
-e.g.
-Just include `osl-docker` in your node's `run_list`:
-
-```json
-{
-  "name":"my_node",
-  "run_list": [
-    "recipe[osl-docker]"
-  ]
-}
-```
+Installs Docker from Docker Inc's repo and starts the docker service
 
 Contributing
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+default['osl-docker']['package']['version'] = '1.13.1'
+default['osl-docker']['service'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,11 @@ description      'Installs/Configures osl-docker'
 long_description 'Installs/Configures osl-docker'
 version          '0.1.0'
 
+depends          'apt'
+depends          'apt-docker'
+depends          'docker', '~> 2.15.0'
+depends          'yum-docker'
+depends          'yum-plugin-versionlock'
+
 supports         'centos', '~> 7.0'
+supports         'debian', '~> 8.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,4 +15,34 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if node['platform_family'] == 'rhel'
+  include_recipe 'yum-docker'
+  include_recipe 'yum-plugin-versionlock'
 
+  yum_version_lock 'docker-engine' do
+    version node['osl-docker']['package']['version']
+    release '1.el7.centos'
+    notifies :makecache, 'yum_repository[docker-main]', :immediately
+  end
+end
+
+include_recipe 'apt-docker' if node['platform_family'] == 'debian'
+
+apt_preference 'docker-engine' do
+  pin "version #{node['osl-docker']['package']['version']}*"
+  pin_priority '1001'
+  only_if { node['platform_family'] == 'debian' }
+end
+
+docker_installation_package 'default' do
+  node['osl-docker']['package'].each do |key, value|
+    send(key.to_sym, value)
+  end
+end
+
+docker_service 'default' do
+  node['osl-docker']['service'].each do |key, value|
+    send(key.to_sym, value)
+  end
+  action [:create, :start]
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,8 +6,55 @@ describe 'osl-docker::default' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+      docker_version = '1.13.1'
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to create_docker_installation_package('default').with(version: docker_version)
+      end
+      it do
+        expect(chef_run).to create_docker_service('default')
+      end
+      it do
+        expect(chef_run).to start_docker_service('default')
+      end
+      case p
+      when CENTOS_6, CENTOS_7
+        it do
+          expect(chef_run).to include_recipe('yum-docker')
+        end
+        it do
+          expect(chef_run).to add_yum_version_lock('docker-engine')
+            .with(
+              version: docker_version,
+              release: '1.el7.centos'
+            )
+        end
+        it do
+          expect(chef_run.yum_version_lock('docker-engine')).to \
+            notify('yum_repository[docker-main]').to(:makecache).immediately
+        end
+        it do
+          expect(chef_run).to_not include_recipe('apt-docker')
+        end
+      when DEBIAN_8
+        it do
+          expect(chef_run).to include_recipe('apt-docker')
+        end
+        it do
+          expect(chef_run).to add_apt_preference('docker-engine')
+            .with(
+              pin: "version #{docker_version}*",
+              pin_priority: '1001'
+            )
+        end
+        it do
+          expect(chef_run).to_not include_recipe('yum-docker')
+        end
+        it do
+          expect(chef_run).to_not add_yum_version_lock('docker-engine')
+        end
       end
     end
   end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,3 +1,16 @@
 require 'serverspec'
 
 set :backend, :exec
+
+describe service('docker') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe command('docker --version') do
+  its(:stdout) { should match(/1\.13\.1/) }
+end
+
+describe command('docker ps') do
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
This pulls in some logic from the various places we're already using docker. The
upstream cookbook doesn't have a default recipe and is only resource driven, so
this cookbook will make an assumption that we want a default docker service
running utilizing dynamic attributes for setting the various parameters for each
resource. A few other notable features:

- Prefer using upstream vendor repositories instead of distribution repos to
  ensure we're using the latest and greatest.
- This uses apt pinning and yum-versionlock to ensure we have the exact version
  of docker installed we want. That way we don't upgrade when we don't want to
  accidentally.