### PR TITLE
Add ppc64le support / Update to latest Docker-ce version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,12 @@
-default['osl-docker']['package']['version'] = '1.13.1'
-default['osl-docker']['package']['package_name'] = 'docker-engine'
+case node['platform_family']
+when 'rhel'
+  default['osl-docker']['package']['version'] = '17.06.1.ce'
+  default['osl-docker']['package_release'] = node['kernel']['machine'] == 'ppc64le' ? '2.el7.centos' : '1.el7.centos'
+  default['osl-docker']['package']['package_version'] =
+    "#{default['osl-docker']['package']['version']}-#{default['osl-docker']['package_release']}"
+  default['osl-docker']['package']['package_name'] = 'docker-ce'
+when 'debian'
+  default['osl-docker']['package']['package_name'] = 'docker-engine'
+  default['osl-docker']['package']['version'] = '17.05.0'
+end
 default['osl-docker']['service'] = {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,18 +8,12 @@ CENTOS_7 = {
   version: '7.2.1511'
 }.freeze
 
-CENTOS_6 = {
-  platform: 'centos',
-  version: '6.7'
-}.freeze
-
 DEBIAN_8 = {
   platform: 'debian',
   version: '8.4'
 }.freeze
 
 ALL_PLATFORMS = [
-  CENTOS_6,
   CENTOS_7,
   DEBIAN_8
 ].freeze

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,12 +6,8 @@ describe 'osl-docker::default' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
-      docker_version = '1.13.1'
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
-      end
-      it do
-        expect(chef_run).to create_docker_installation_package('default').with(version: docker_version)
       end
       it do
         expect(chef_run).to create_docker_service('default')
@@ -20,32 +16,69 @@ describe 'osl-docker::default' do
         expect(chef_run).to start_docker_service('default')
       end
       case p
-      when CENTOS_6, CENTOS_7
+      when CENTOS_7
+        it do
+          expect(chef_run).to create_docker_installation_package('default').with(version: '17.06.1.ce')
+        end
+        context 'ppc64le' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.automatic['kernel']['machine'] = 'ppc64le'
+            end.converge(described_recipe)
+          end
+          it do
+            expect(chef_run).to add_yum_version_lock('docker-ce')
+              .with(
+                version: '17.06.1.ce',
+                release: '2.el7.centos'
+              )
+          end
+          it do
+            expect(chef_run).to create_yum_repository('docker-main')
+              .with(
+                baseurl: 'http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/',
+                gpgcheck: false
+              )
+          end
+        end
+        it do
+          expect(chef_run).to create_yum_repository('docker-main')
+            .with(
+              baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable/',
+              gpgkey: 'https://download.docker.com/linux/centos/gpg'
+            )
+        end
         it do
           expect(chef_run).to include_recipe('yum-docker')
         end
         it do
-          expect(chef_run).to add_yum_version_lock('docker-engine')
+          expect(chef_run).to add_yum_version_lock('docker-ce')
             .with(
-              version: docker_version,
+              version: '17.06.1.ce',
               release: '1.el7.centos'
             )
         end
         it do
-          expect(chef_run.yum_version_lock('docker-engine')).to \
+          expect(chef_run.yum_version_lock('docker-ce')).to \
             notify('yum_repository[docker-main]').to(:makecache).immediately
         end
         it do
           expect(chef_run).to_not include_recipe('apt-docker')
         end
+        it do
+          expect(chef_run).to_not add_apt_preference('docker-ce')
+        end
       when DEBIAN_8
+        it do
+          expect(chef_run).to create_docker_installation_package('default').with(version: '17.05.0')
+        end
         it do
           expect(chef_run).to include_recipe('apt-docker')
         end
         it do
           expect(chef_run).to add_apt_preference('docker-engine')
             .with(
-              pin: "version #{docker_version}*",
+              pin: 'version 17.05.0*',
               pin_priority: '1001'
             )
         end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -8,7 +8,12 @@ describe service('docker') do
 end
 
 describe command('docker --version') do
-  its(:stdout) { should match(/1\.13\.1/) }
+  case os[:family]
+  when 'redhat'
+    its(:stdout) { should match(/17\.06\.1-ce/) }
+  when 'debian'
+    its(:stdout) { should match(/17\.05\.0-ce/) }
+  end
 end
 
 describe command('docker ps') do

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -8,7 +8,7 @@ describe service('docker') do
 end
 
 describe command('docker --version') do
-  its(:stdout) { should match(/1\.13\.1/) }
+  its(:stdout) { should match(/17\.06\.1-ce/) }
 end
 
 describe command('docker ps') do


### PR DESCRIPTION
Upstream docker doesn't officially have packages for docker on ppc64le. This
uses a repository from the Unicamp university which provides some newer releases
than what's included in CentOS proper. This adds some logic to work around
issues between the two architectures.

In addition, this upgrades the docker version from 1.13.1 to 17.06.1 on CentOS
and 17.05.0 on Debian. There doesn't seem to be a release of 17.06.1 on Debian
yet so we had to go with the latest version on there. This will upgrade docker
on the workstations so we'll have to watch and see what issues that cause.