### PR TITLE
Remove apt-docker cookbook and add repository manually

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ long_description 'Installs/Configures osl-docker'
 version          '1.2.2'
 
 depends          'apt'
-depends          'apt-docker'
 depends          'docker', '~> 2.15.0'
 depends          'firewall', '>= 4.4.4'
 depends          'magic_shell'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,14 @@ if node['platform_family'] == 'rhel'
 
 end
 
-include_recipe 'apt-docker' if node['platform_family'] == 'debian'
+apt_repository 'docker-main' do
+  uri 'https://apt.dockerproject.org/repo'
+  components %w(main)
+  keyserver 'hkp://p80.pool.sks-keyservers.net:80'
+  distribution "#{node['platform']}-#{node['lsb']['codename']}"
+  key '58118E89F3A912897C070ADBF76221572C52609D'
+  only_if { node['platform_family'] == 'debian' }
+end
 
 apt_preference node['osl-docker']['package']['package_name'] do
   pin "version #{node['osl-docker']['package']['version']}*"

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -63,7 +63,7 @@ describe 'osl-docker::default' do
             notify('yum_repository[docker-main]').to(:makecache).immediately
         end
         it do
-          expect(chef_run).to_not include_recipe('apt-docker')
+          expect(chef_run).to_not add_apt_repository('docker-main')
         end
         it do
           expect(chef_run).to_not add_apt_preference('docker-ce')
@@ -73,7 +73,14 @@ describe 'osl-docker::default' do
           expect(chef_run).to create_docker_installation_package('default').with(version: '17.05.0')
         end
         it do
-          expect(chef_run).to include_recipe('apt-docker')
+          expect(chef_run).to add_apt_repository('docker-main')
+            .with(
+              uri: 'https://apt.dockerproject.org/repo',
+              components: %w(main),
+              keyserver: 'hkp://p80.pool.sks-keyservers.net:80',
+              distribution: 'debian-jessie',
+              key: '58118E89F3A912897C070ADBF76221572C52609D'
+            )
         end
         it do
           expect(chef_run).to add_apt_preference('docker-engine')


### PR DESCRIPTION
The apt-docker cookbook seems to be unmaintained and as a pessimistic dependency
on apt which is causing issues elsewhere. This should resolve that issue.