### PR TITLE
Prune docker volumes and images via cronjob

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,3 +72,8 @@ docker_service 'default' do
   end
   action [:create, :start]
 end
+
+magic_shell_environment 'DOCKER_HOST' do
+  value node['osl-docker']['service']['host']
+  only_if { node['osl-docker']['service']['host'] }
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -77,3 +77,17 @@ magic_shell_environment 'DOCKER_HOST' do
   value node['osl-docker']['service']['host']
   only_if { node['osl-docker']['service']['host'] }
 end
+
+cron 'docker_prune_volumes' do
+  minute 15
+  environment(DOCKER_HOST: node['osl-docker']['service']['host']) if node['osl-docker']['service']['host']
+  command '/usr/bin/docker system prune --volumes -f > /dev/null'
+end
+
+cron 'docker_prune_images' do
+  minute 45
+  hour 2
+  weekday 0
+  environment(DOCKER_HOST: node['osl-docker']['service']['host']) if node['osl-docker']['service']['host']
+  command '/usr/bin/docker system prune -a -f > /dev/null'
+end

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -20,9 +20,5 @@ node.override['osl-docker']['service'] = { host: 'tcp://0.0.0.0:2375' }
 node.default['firewall']['docker']['range']['4'] = %w(192.168.6.0/24)
 node.default['firewall']['docker']['expose_ports'] = true
 
-magic_shell_environment 'DOCKER_HOST' do
-  value 'tcp://0.0.0.0:2375'
-end
-
 include_recipe 'osl-docker::default'
 include_recipe 'firewall::docker'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,6 +15,19 @@ describe 'osl-docker::default' do
       it do
         expect(chef_run).to start_docker_service('default')
       end
+      it do
+        expect(chef_run).to_not add_magic_shell_environment('DOCKER_HOST')
+      end
+      context 'DOCKER_HOST set' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.set['osl-docker']['service']['host'] = 'tcp://127.0.0.1:2375'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to add_magic_shell_environment('DOCKER_HOST').with(value: 'tcp://127.0.0.1:2375')
+        end
+      end
       case p
       when CENTOS_7
         it do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -18,6 +18,24 @@ describe 'osl-docker::default' do
       it do
         expect(chef_run).to_not add_magic_shell_environment('DOCKER_HOST')
       end
+      it do
+        expect(chef_run).to create_cron('docker_prune_volumes')
+          .with(
+            minute: '15',
+            environment: {},
+            command: '/usr/bin/docker system prune --volumes -f > /dev/null'
+          )
+      end
+      it do
+        expect(chef_run).to create_cron('docker_prune_images')
+          .with(
+            minute: '45',
+            hour: '2',
+            weekday: '0',
+            environment: {},
+            command: '/usr/bin/docker system prune -a -f > /dev/null'
+          )
+      end
       context 'DOCKER_HOST set' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|
@@ -26,6 +44,24 @@ describe 'osl-docker::default' do
         end
         it do
           expect(chef_run).to add_magic_shell_environment('DOCKER_HOST').with(value: 'tcp://127.0.0.1:2375')
+        end
+        it do
+          expect(chef_run).to create_cron('docker_prune_volumes')
+            .with(
+              minute: '15',
+              environment: { DOCKER_HOST: 'tcp://127.0.0.1:2375' },
+              command: '/usr/bin/docker system prune --volumes -f > /dev/null'
+            )
+        end
+        it do
+          expect(chef_run).to create_cron('docker_prune_images')
+            .with(
+              minute: '45',
+              hour: '2',
+              weekday: '0',
+              environment: { DOCKER_HOST: 'tcp://127.0.0.1:2375' },
+              command: '/usr/bin/docker system prune -a -f > /dev/null'
+            )
         end
       end
       case p

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -15,11 +15,6 @@ describe 'osl-docker::powerci' do
         )
       end
       it do
-        expect(chef_run).to add_magic_shell_environment('DOCKER_HOST').with(
-          value: 'tcp://0.0.0.0:2375'
-        )
-      end
-      it do
         expect(chef_run).to create_iptables_ng_rule('docker_ipv4')
           .with(
             rule: [

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -3,3 +3,8 @@ require 'spec_helper'
 describe 'docker' do
   it_behaves_like 'docker'
 end
+
+describe cron do
+  it { should have_entry('15 * * * * /usr/bin/docker system prune --volumes -f > /dev/null') }
+  it { should have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f > /dev/null') }
+end

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -8,6 +8,10 @@ describe port(2375) do
   it { should be_listening }
 end
 
+describe cron do
+  its(:table) { should match(%r{^DOCKER_HOST=tcp://0\.0\.0\.0:2375$}) }
+end
+
 describe iptables do
   it { should have_rule('-A docker -s 192.168.6.0/24 -p tcp -m tcp --dport 2375 -j ACCEPT') }
   it { should have_rule('-A docker -s 192.168.6.0/24 -p tcp -m tcp --dport 2376 -j ACCEPT') }


### PR DESCRIPTION
This provides two cronjobs:

- Prune unused volumes hourly
- Prune unused images weekly

This ensures we're not running out of disk space on docker hosts.

This shouldn't be merged until osuosl/chef-repo#1170 is deployed.