### PR TITLE
Bump to docker-ce-17.09.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,7 @@ suites:
       - recipe[osl-docker::powerci]
     excludes:
       - debian-8
+      - debian-9
   - name: workstation
     run_list:
       - recipe[osl-docker::workstation]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,12 @@
 case node['platform_family']
 when 'rhel'
-  default['osl-docker']['package']['version'] = '17.06.1.ce'
-  default['osl-docker']['package_release'] = node['kernel']['machine'] == 'ppc64le' ? '2.el7.centos' : '1.el7.centos'
+  default['osl-docker']['package']['version'] = '17.09.0.ce'
+  default['osl-docker']['package_release'] = '1.el7.centos'
   default['osl-docker']['package']['package_version'] =
     "#{default['osl-docker']['package']['version']}-#{default['osl-docker']['package_release']}"
   default['osl-docker']['package']['package_name'] = 'docker-ce'
 when 'debian'
-  default['osl-docker']['package']['package_name'] = 'docker-engine'
-  default['osl-docker']['package']['version'] = '17.05.0'
+  default['osl-docker']['package']['package_name'] = 'docker-ce'
+  default['osl-docker']['package']['version'] = '17.09.0'
 end
 default['osl-docker']['service'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,3 +18,4 @@ depends          'yum-plugin-versionlock'
 
 supports         'centos', '~> 7.0'
 supports         'debian', '~> 8.0'
+supports         'debian', '~> 9.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,12 +39,17 @@ if node['platform_family'] == 'rhel'
 
 end
 
+# Needed on Debian 9 to import the GPG key
+package 'dirmngr' do
+  only_if { node['platform_family'] == 'debian' && node['platform_version'].to_i >= 9 }
+end
+
 apt_repository 'docker-main' do
-  uri 'https://apt.dockerproject.org/repo'
-  components %w(main)
+  uri 'https://download.docker.com/linux/debian'
+  components %w(stable)
+  distribution node['lsb']['codename']
   keyserver 'hkp://p80.pool.sks-keyservers.net:80'
-  distribution "#{node['platform']}-#{node['lsb']['codename']}"
-  key '58118E89F3A912897C070ADBF76221572C52609D'
+  key '0EBFCD88'
   only_if { node['platform_family'] == 'debian' }
 end
 
@@ -58,6 +63,7 @@ docker_installation_package 'default' do
   node['osl-docker']['package'].each do |key, value|
     send(key.to_sym, value)
   end
+  notifies :restart, 'docker_service[default]'
 end
 
 docker_service 'default' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -18,20 +18,13 @@ describe 'osl-docker::default' do
       case p
       when CENTOS_7
         it do
-          expect(chef_run).to create_docker_installation_package('default').with(version: '17.06.1.ce')
+          expect(chef_run).to create_docker_installation_package('default').with(version: '17.09.0.ce')
         end
         context 'ppc64le' do
           cached(:chef_run) do
             ChefSpec::SoloRunner.new(p) do |node|
               node.automatic['kernel']['machine'] = 'ppc64le'
             end.converge(described_recipe)
-          end
-          it do
-            expect(chef_run).to add_yum_version_lock('docker-ce')
-              .with(
-                version: '17.06.1.ce',
-                release: '2.el7.centos'
-              )
           end
           it do
             expect(chef_run).to create_yum_repository('docker-main')
@@ -54,7 +47,7 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to add_yum_version_lock('docker-ce')
             .with(
-              version: '17.06.1.ce',
+              version: '17.09.0.ce',
               release: '1.el7.centos'
             )
         end
@@ -68,24 +61,27 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to_not add_apt_preference('docker-ce')
         end
+        it do
+          expect(chef_run).to_not install_package('dirmgr')
+        end
       when DEBIAN_8
         it do
-          expect(chef_run).to create_docker_installation_package('default').with(version: '17.05.0')
+          expect(chef_run).to create_docker_installation_package('default').with(version: '17.09.0')
         end
         it do
           expect(chef_run).to add_apt_repository('docker-main')
             .with(
-              uri: 'https://apt.dockerproject.org/repo',
-              components: %w(main),
+              uri: 'https://download.docker.com/linux/debian',
+              components: %w(stable),
+              distribution: 'jessie',
               keyserver: 'hkp://p80.pool.sks-keyservers.net:80',
-              distribution: 'debian-jessie',
-              key: '58118E89F3A912897C070ADBF76221572C52609D'
+              key: '0EBFCD88'
             )
         end
         it do
-          expect(chef_run).to add_apt_preference('docker-engine')
+          expect(chef_run).to add_apt_preference('docker-ce')
             .with(
-              pin: 'version 17.05.0*',
+              pin: 'version 17.09.0*',
               pin_priority: '1001'
             )
         end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -8,12 +8,7 @@ shared_examples_for 'docker' do |docker_env|
   end
 
   describe command('docker --version') do
-    case os[:family]
-    when 'redhat'
-      its(:stdout) { should match(/17\.06\.1-ce/) }
-    when 'debian'
-      its(:stdout) { should match(/17\.05\.0-ce/) }
-    end
+    its(:stdout) { should match(/17\.09\.0-ce/) }
   end
 
   describe command("#{docker_env} docker ps") do


### PR DESCRIPTION
This bumps all platforms and archs to the same version, 17.09.0. This includes
some features that are being used in #10.

This also does the following:
- Adds Debian 9 to test-kitchen
- Updates apt repository to use the new Docker apt repo
- Restart the docker service after the package is installed or upgraded
- Use docker-ce instead of docker-engine for Debian systems
- The minor release for ppc64le is now the same as x86_64