### PR TITLE
Install docker-compose binary

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,9 @@ suites:
   - name: default
     run_list:
       - recipe[osl-docker::default]
+  - name: compose
+    run_list:
+      - recipe[osl-docker::compose]
   - name: powerci
     run_list:
       - recipe[osl-docker::powerci]

--- a/attributes/compose.rb
+++ b/attributes/compose.rb
@@ -1,0 +1,10 @@
+default['osl-docker']['compose']['version'] = '1.18.0'
+default['osl-docker']['compose']['filename'] = "docker-compose-Linux-#{node['kernel']['machine']}"
+case node['kernel']['machine']
+when 'x86_64'
+  default['osl-docker']['compose']['checksum'] = 'b2f2c3834107f526b1d9cc8d8e0bdd132c6f1495b036a32cbc61b5288d2e2a01'
+  default['osl-docker']['compose']['url_base'] = 'https://github.com/docker/compose/releases/download'
+when 'ppc64le'
+  default['osl-docker']['compose']['checksum'] = '4458de249ca5f776738e44a6af2f869c1186b2d018dd15705045aa01a45e50c5'
+  default['osl-docker']['compose']['url_base'] = 'http://ftp.osuosl.org/pub/osl/openpower/docker-compose'
+end

--- a/recipes/compose.rb
+++ b/recipes/compose.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook:: osl-docker
+# Recipe:: compose
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+compose = node['osl-docker']['compose']
+
+remote_file '/usr/local/bin/docker-compose' do
+  source "#{compose['url_base']}/#{compose['version']}/#{compose['filename']}"
+  checksum compose['checksum']
+  mode '0755'
+end

--- a/spec/unit/recipes/compose_spec.rb
+++ b/spec/unit/recipes/compose_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+
+describe 'osl-docker::compose' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to create_remote_file('/usr/local/bin/docker-compose')
+          .with(
+            source: 'https://github.com/docker/compose/releases/download/1.18.0/docker-compose-Linux-x86_64',
+            checksum: 'b2f2c3834107f526b1d9cc8d8e0bdd132c6f1495b036a32cbc61b5288d2e2a01',
+            mode: '0755'
+          )
+      end
+      case p
+      when CENTOS_7
+        context 'ppc64le' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.automatic['kernel']['machine'] = 'ppc64le'
+            end.converge(described_recipe)
+          end
+          it do
+            expect(chef_run).to create_remote_file('/usr/local/bin/docker-compose')
+              .with(
+                source: 'http://ftp.osuosl.org/pub/osl/openpower/docker-compose/1.18.0/docker-compose-Linux-ppc64le',
+                checksum: '4458de249ca5f776738e44a6af2f869c1186b2d018dd15705045aa01a45e50c5',
+                mode: '0755'
+              )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/compose/serverspec/compose_spec.rb
+++ b/test/integration/compose/serverspec/compose_spec.rb
@@ -1,0 +1,8 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe command('/usr/local/bin/docker-compose version') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/docker-compose version 1.18.0/) }
+end


### PR DESCRIPTION
This adds a compose recipe which installs the docker-compose binary. Upstream
doesn't provide a binary for ppc64le, so I made one for our use. This is one
release behind since I originally built the ppc64le binary before 1.19.0 was
released. I'll work on pushing up the code for that soon in a fork and then try
and get proper support upstream. This also unifies how we install docker-compose
globally if we need it elsewhere.

This will replace the pip installs we do on the workstations and will require us
removing docker-compose from the workstation environment when merged.