### PR TITLE
Lock apt cookbook to < 7.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ description      'Installs/Configures osl-docker'
 long_description 'Installs/Configures osl-docker'
 version          '1.7.0'
 
-depends          'apt'
+depends          'apt', '< 7.0.0'
 depends          'certificate'
 depends          'docker', '~> 2.15.0'
 depends          'firewall', '>= 4.4.4'


### PR DESCRIPTION
The apt cookbook is no longer compatible with our chef-client version and also
deprecated the ``apt_preference`` resource[1]. This lock will make sure that we use a
compatible version until we upgrade.

[1] https://github.com/chef-cookbooks/apt/commit/2c3f8de9d03672afa601f4fcb1225ac23ae99120