### PR TITLE
Enable docker socket by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,4 +21,5 @@ else
 end
 default['osl-docker']['service'] = {}
 default['osl-docker']['tls'] = false
+default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil
 default['osl-docker']['data_bag'] = 'docker'

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 node.default['firewall']['docker']['expose_ports'] = true
 node.default['osl-docker']['tls'] = true
-node.override['osl-docker']['service'] = { host: 'tcp://0.0.0.0:2376' }
+node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2376'
 
 include_recipe 'osl-docker::default'
 include_recipe 'firewall::docker'

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.override['osl-docker']['service'] = { host: 'tcp://0.0.0.0:2375' }
+node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2375'
 node.default['firewall']['docker']['range']['4'] = %w(192.168.6.0/24 140.211.168.207/32)
 node.default['firewall']['docker']['expose_ports'] = true
 

--- a/recipes/workstation.rb
+++ b/recipes/workstation.rb
@@ -15,15 +15,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-node.override['osl-docker']['service'] = { host: 'tcp://127.0.0.1:2375' }
+node.override['osl-docker']['host'] = 'tcp://127.0.0.1:2375'
 
 magic_shell_environment 'DOCKER_HOST' do
   value 'tcp://127.0.0.1:2375'
-end
-
-# cleanup old config from workstation::docker
-systemd_socket 'docker' do
-  action [:delete]
 end
 
 include_recipe 'osl-docker::default'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -60,7 +60,7 @@ describe 'osl-docker::default' do
       context 'DOCKER_HOST set' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|
-            node.set['osl-docker']['service']['host'] = 'tcp://127.0.0.1:2375'
+            node.set['osl-docker']['host'] = 'tcp://127.0.0.1:2375'
           end.converge(described_recipe)
         end
         it do

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -11,7 +11,7 @@ describe 'osl-docker::ibmz_ci' do
       end
       it do
         expect(chef_run).to create_docker_service('default').with(
-          host: ['tcp://0.0.0.0:2376']
+          host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2376']
         )
       end
     end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -11,7 +11,7 @@ describe 'osl-docker::powerci' do
       end
       it do
         expect(chef_run).to create_docker_service('default').with(
-          host: ['tcp://0.0.0.0:2375']
+          host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']
         )
       end
       it do

--- a/spec/unit/recipes/workstation_spec.rb
+++ b/spec/unit/recipes/workstation_spec.rb
@@ -11,16 +11,13 @@ describe 'osl-docker::workstation' do
       end
       it do
         expect(chef_run).to create_docker_service('default').with(
-          host: ['tcp://127.0.0.1:2375']
+          host: ['unix:///var/run/docker.sock', 'tcp://127.0.0.1:2375']
         )
       end
       it do
         expect(chef_run).to add_magic_shell_environment('DOCKER_HOST').with(
           value: 'tcp://127.0.0.1:2375'
         )
-      end
-      it do
-        expect(chef_run).to delete_systemd_socket('docker')
       end
     end
   end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -14,4 +14,8 @@ shared_examples_for 'docker' do |docker_env|
   describe command("#{docker_env} docker ps") do
     its(:exit_status) { should eq 0 }
   end
+
+  describe command('docker ps') do
+    its(:exit_status) { should eq 0 }
+  end
 end

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'docker' do
-  it_behaves_like 'docker'
+  it_behaves_like 'docker', 'DOCKER_HOST="tcp://0.0.0.0:2375"'
 end
 
 describe port(2375) do

--- a/test/integration/workstation/serverspec/workstation_spec.rb
+++ b/test/integration/workstation/serverspec/workstation_spec.rb
@@ -7,7 +7,3 @@ end
 describe port(2375) do
   it { should be_listening.on('127.0.0.1').with('tcp') }
 end
-
-describe file('/etc/systemd/system/docker.socket') do
-  it { should_not exist }
-end


### PR DESCRIPTION
On hosts that have TCP enabled, we had been disabling the unix socket connection
too. This works great however if you try to run any other docker resources
during the same run, it fails since it doesn't have the ``DOCKER_HOST`` environment
setup. To work around this, I recommend we just keep the socket enabled no
matter what for backwards compatibility.

This required re-factoring the code a bit and creating a new attribute to track
what host you want to have it set as.