### PR TITLE
Remove DOCKER_HOST from cron jobs

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -147,7 +147,6 @@ end
 
 cron 'docker_prune_volumes' do
   minute 15
-  environment(DOCKER_HOST: node['osl-docker']['host']) if node['osl-docker']['host']
   command '/usr/bin/docker system prune --volumes -f > /dev/null'
 end
 
@@ -155,6 +154,5 @@ cron 'docker_prune_images' do
   minute 45
   hour 2
   weekday 0
-  environment(DOCKER_HOST: node['osl-docker']['host']) if node['osl-docker']['host']
   command '/usr/bin/docker system prune -a -f > /dev/null'
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -70,7 +70,6 @@ describe 'osl-docker::default' do
           expect(chef_run).to create_cron('docker_prune_volumes')
             .with(
               minute: '15',
-              environment: { DOCKER_HOST: 'tcp://127.0.0.1:2375' },
               command: '/usr/bin/docker system prune --volumes -f > /dev/null'
             )
         end
@@ -80,7 +79,6 @@ describe 'osl-docker::default' do
               minute: '45',
               hour: '2',
               weekday: '0',
-              environment: { DOCKER_HOST: 'tcp://127.0.0.1:2375' },
               command: '/usr/bin/docker system prune -a -f > /dev/null'
             )
         end


### PR DESCRIPTION
This is no longer needed since we have the docker socket enabled by default no
matter what. With this set, this is currently broken on the s390x hosts since it
requires two more environment variables to work properly.