### PR TITLE
volume fixes for powerci/ibmz

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@ else
   default['osl-docker']['tarball'] = {}
 end
 default['osl-docker']['service'] = {}
+default['osl-docker']['prune']['volume_filter'] = []
 default['osl-docker']['tls'] = false
 default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil
 default['osl-docker']['data_bag'] = 'docker'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -145,14 +145,21 @@ docker_service 'default' do
   action [:create, :start]
 end
 
+volume_filter = []
+unless node['osl-docker']['prune']['volume_filter'].empty?
+  node['osl-docker']['prune']['volume_filter'].each do |f|
+    volume_filter << "--filter #{f}"
+  end
+end
+
 cron 'docker_prune_volumes' do
   minute 15
-  command '/usr/bin/docker system prune --volumes -f > /dev/null'
+  command "/usr/bin/docker system prune --volumes -f #{volume_filter.join(' ')} > /dev/null"
 end
 
 cron 'docker_prune_images' do
   minute 45
   hour 2
   weekday 0
-  command '/usr/bin/docker system prune -a -f > /dev/null'
+  command "/usr/bin/docker system prune -a -f #{volume_filter.join(' ')} > /dev/null"
 end

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 node.default['firewall']['docker']['expose_ports'] = true
+node.default['osl-docker']['prune']['volume_filter'] = %w(label!=preserve=true)
 node.default['osl-docker']['tls'] = true
 node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2376'
 

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -22,4 +22,7 @@ node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2376'
 include_recipe 'osl-docker::default'
 include_recipe 'firewall::docker'
 
-docker_volume 'ccache'
+# docker_volume resource does not have support for labels
+execute 'docker volume create --label preserve=true ccache' do
+  not_if 'docker volume inspect ccache'
+end

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -23,4 +23,7 @@ node.default['firewall']['docker']['expose_ports'] = true
 include_recipe 'osl-docker::default'
 include_recipe 'firewall::docker'
 
-docker_volume 'ccache'
+# docker_volume resource does not have support for labels
+execute 'docker volume create --label preserve=true ccache' do
+  not_if 'docker volume inspect ccache'
+end

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2375'
+node.default['osl-docker']['prune']['volume_filter'] = %w(label!=preserve=true)
 node.default['firewall']['docker']['range']['4'] = %w(192.168.6.0/24 140.211.168.207/32)
 node.default['firewall']['docker']['expose_ports'] = true
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -44,7 +44,7 @@ describe 'osl-docker::default' do
           .with(
             minute: '15',
             environment: {},
-            command: '/usr/bin/docker system prune --volumes -f > /dev/null'
+            command: '/usr/bin/docker system prune --volumes -f  > /dev/null'
           )
       end
       it do
@@ -54,7 +54,7 @@ describe 'osl-docker::default' do
             hour: '2',
             weekday: '0',
             environment: {},
-            command: '/usr/bin/docker system prune -a -f > /dev/null'
+            command: '/usr/bin/docker system prune -a -f  > /dev/null'
           )
       end
       context 'DOCKER_HOST set' do
@@ -70,7 +70,7 @@ describe 'osl-docker::default' do
           expect(chef_run).to create_cron('docker_prune_volumes')
             .with(
               minute: '15',
-              command: '/usr/bin/docker system prune --volumes -f > /dev/null'
+              command: '/usr/bin/docker system prune --volumes -f  > /dev/null'
             )
         end
         it do
@@ -79,7 +79,7 @@ describe 'osl-docker::default' do
               minute: '45',
               hour: '2',
               weekday: '0',
-              command: '/usr/bin/docker system prune -a -f > /dev/null'
+              command: '/usr/bin/docker system prune -a -f  > /dev/null'
             )
         end
       end

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -6,6 +6,9 @@ describe 'osl-docker::ibmz_ci' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+      before do
+        stub_command('docker volume inspect ccache').and_return(false)
+      end
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
@@ -15,7 +18,18 @@ describe 'osl-docker::ibmz_ci' do
         )
       end
       it do
-        expect(chef_run).to create_docker_volume('ccache')
+        expect(chef_run).to run_execute('docker volume create --label preserve=true ccache')
+      end
+      context 'ccache volume already exists' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p).converge(described_recipe)
+        end
+        before do
+          stub_command('docker volume inspect ccache').and_return(true)
+        end
+        it do
+          expect(chef_run).to_not run_execute('docker volume create --label preserve=true ccache')
+        end
       end
     end
   end

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -18,6 +18,18 @@ describe 'osl-docker::ibmz_ci' do
         )
       end
       it do
+        expect(chef_run).to create_cron('docker_prune_volumes')
+          .with(
+            command: '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null'
+          )
+      end
+      it do
+        expect(chef_run).to create_cron('docker_prune_images')
+          .with(
+            command: '/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null'
+          )
+      end
+      it do
         expect(chef_run).to run_execute('docker volume create --label preserve=true ccache')
       end
       context 'ccache volume already exists' do

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -18,6 +18,18 @@ describe 'osl-docker::powerci' do
         )
       end
       it do
+        expect(chef_run).to create_cron('docker_prune_volumes')
+          .with(
+            command: '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null'
+          )
+      end
+      it do
+        expect(chef_run).to create_cron('docker_prune_images')
+          .with(
+            command: '/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null'
+          )
+      end
+      it do
         expect(chef_run).to create_iptables_ng_rule('docker_ipv4')
           .with(
             rule: [

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -6,6 +6,9 @@ describe 'osl-docker::powerci' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+      before do
+        stub_command('docker volume inspect ccache').and_return(false)
+      end
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
@@ -35,7 +38,18 @@ describe 'osl-docker::powerci' do
           )
       end
       it do
-        expect(chef_run).to create_docker_volume('ccache')
+        expect(chef_run).to run_execute('docker volume create --label preserve=true ccache')
+      end
+      context 'ccache volume already exists' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p).converge(described_recipe)
+        end
+        before do
+          stub_command('docker volume inspect ccache').and_return(true)
+        end
+        it do
+          expect(chef_run).to_not run_execute('docker volume create --label preserve=true ccache')
+        end
       end
     end
   end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -5,6 +5,6 @@ describe 'docker' do
 end
 
 describe cron do
-  it { should have_entry('15 * * * * /usr/bin/docker system prune --volumes -f > /dev/null') }
-  it { should have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f > /dev/null') }
+  it { should have_entry('15 * * * * /usr/bin/docker system prune --volumes -f  > /dev/null') }
+  it { should have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f  > /dev/null') }
 end

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -10,6 +10,11 @@ describe port(2376) do
   it { should be_listening }
 end
 
+describe cron do
+  its(:table) { should match(%r{/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null}) }
+  its(:table) { should match(%r{/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null}) }
+end
+
 describe command('docker volume inspect ccache') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{"Mountpoint": "/var/lib/docker/volumes/ccache/_data"}) }

--- a/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/serverspec/ibmz_ci_spec.rb
@@ -14,4 +14,5 @@ describe command('docker volume inspect ccache') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{"Mountpoint": "/var/lib/docker/volumes/ccache/_data"}) }
   its(:stdout) { should match(/"Name": "ccache"/) }
+  its(:stdout) { should match(/"Labels": {\n.*"preserve": "true"/) }
 end

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -8,10 +8,6 @@ describe port(2375) do
   it { should be_listening }
 end
 
-describe cron do
-  its(:table) { should match(%r{^DOCKER_HOST=tcp://0\.0\.0\.0:2375$}) }
-end
-
 describe iptables do
   ['192.168.6.0/24', '140.211.168.207/32'].each do |ip|
     it { should have_rule("-A docker -s #{ip} -p tcp -m tcp --dport 2375 -j ACCEPT") }
@@ -24,4 +20,5 @@ describe command('docker volume inspect ccache') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{"Mountpoint": "/var/lib/docker/volumes/ccache/_data"}) }
   its(:stdout) { should match(/"Name": "ccache"/) }
+  its(:stdout) { should match(/"Labels": {\n.*"preserve": "true"/) }
 end

--- a/test/integration/powerci/serverspec/powerci_spec.rb
+++ b/test/integration/powerci/serverspec/powerci_spec.rb
@@ -8,6 +8,11 @@ describe port(2375) do
   it { should be_listening }
 end
 
+describe cron do
+  its(:table) { should match(%r{/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null}) }
+  its(:table) { should match(%r{/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null}) }
+end
+
 describe iptables do
   ['192.168.6.0/24', '140.211.168.207/32'].each do |ip|
     it { should have_rule("-A docker -s #{ip} -p tcp -m tcp --dport 2375 -j ACCEPT") }


### PR DESCRIPTION
## Create ccache volume with preserve=true label

This adds support to use filters when running ``docker system prune``. In the
case for powerci/ibmz, this excludes the ``ccache`` volume that we create from
being pruned hourly (oops!)

## Filter volumes to prune or not prune

The docker_volume resource does not support setting a label on the volume and
thus we need to manually run the command using the execute resource.

In addition, remove test that is no longer needed