### PR TITLE
Chef 13 compatibility fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Rakefile
+++ b/Rakefile
@@ -110,9 +110,10 @@ task snakeoil: snakeoil_file_path
 desc 'Create an Encrypted Databag Secret'
 task secret_file: encrypted_data_bag_secret_path
 
-require 'rubocop/rake_task'
-desc 'Run RuboCop (style) tests'
-RuboCop::RakeTask.new(:style)
+desc 'Run RuboCop (cookstyle) tests'
+task :style do
+  run_command('cookstyle')
+end
 
 desc 'Run FoodCritic (lint) tests'
 task :lint do

--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,10 @@ end
 #
 def gen_ssl_cert
   name = OpenSSL::X509::Name.new [
-    ['C', 'US'],
-    ['ST', 'Oregon'],
+    %w(C US),
+    %w(ST Oregon),
     ['CN', 'OSU Open Source Lab'],
-    ['DC', 'example']
+    %w(DC example),
   ]
   key = OpenSSL::PKey::RSA.new 2048
 
@@ -45,7 +45,7 @@ def gen_ssl_cert
   cert.issuer = name
   cert.sign(key, OpenSSL::Digest::SHA1.new)
 
-  return cert, key
+  [cert, key]
 end
 
 ##
@@ -88,7 +88,7 @@ directory 'test/integration/data_bags/certificates' => 'test/integration'
 #
 file snakeoil_file_path => [
   'test/integration/data_bags/certificates',
-  'test/integration/encrypted_data_bag_secret'
+  'test/integration/encrypted_data_bag_secret',
 ] do
 
   encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
@@ -117,13 +117,13 @@ end
 
 desc 'Run FoodCritic (lint) tests'
 task :lint do
-    run_command('foodcritic --epic-fail any .')
+  run_command('foodcritic --epic-fail any .')
 end
 
 desc 'Run RSpec (unit) tests'
 task :unit do
-    run_command('rm -f Berksfile.lock')
-    run_command('rspec')
+  run_command('rm -f Berksfile.lock')
+  run_command('rspec')
 end
 
 desc 'Run all tests'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,7 @@ depends          'docker', '~> 2.15.0'
 depends          'firewall', '>= 4.4.4'
 depends          'systemd', '< 3.0.0'
 depends          'magic_shell'
+depends          'chef-apt-docker', '~> 2.0.6'
 depends          'chef-yum-docker', '~> 3.1.1'
 depends          'yum-plugin-versionlock'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,8 @@
 name             'osl-docker'
 maintainer       'Oregon State University'
 maintainer_email 'chef@osuosl.org'
-license          'apachev2'
+license          'Apache-2.0'
+chef_version     '>= 12.18' if respond_to?(:chef_version)
 issues_url       'https://github.com/osuosl-cookbooks/osl-docker/issues'
 source_url       'https://github.com/osuosl-cookbooks/osl-docker'
 description      'Installs/Configures osl-docker'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ depends          'docker', '~> 2.15.0'
 depends          'firewall', '>= 4.4.4'
 depends          'systemd', '< 3.0.0'
 depends          'magic_shell'
-depends          'yum-docker'
+depends          'chef-yum-docker', '~> 3.1.1'
 depends          'yum-plugin-versionlock'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,25 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 if node['platform_family'] == 'rhel' && node['kernel']['machine'] != 's390x'
-  include_recipe 'yum-docker'
+  include_recipe 'chef-yum-docker'
   include_recipe 'yum-plugin-versionlock'
 
   if node['kernel']['machine'] == 'ppc64le'
-    edit_resource(:yum_repository, 'docker-main') do
+    edit_resource(:yum_repository, 'docker-stable') do
       baseurl 'http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/'
       gpgcheck false
-    end
-  else
-    edit_resource(:yum_repository, 'docker-main') do
-      baseurl 'https://download.docker.com/linux/centos/7/x86_64/stable/'
-      gpgkey 'https://download.docker.com/linux/centos/gpg'
     end
   end
 
   yum_version_lock node['osl-docker']['package']['package_name'] do
     version node['osl-docker']['package']['version']
     release node['osl-docker']['package_release']
-    notifies :makecache, 'yum_repository[docker-main]', :immediately
+    notifies :makecache, 'yum_repository[docker-stable]', :immediately
   end
 end
 
@@ -43,7 +38,7 @@ package 'dirmngr' do
   only_if { node['platform_family'] == 'debian' && node['platform_version'].to_i >= 9 }
 end
 
-apt_repository 'docker-main' do
+apt_repository 'docker-stable' do
   uri 'https://download.docker.com/linux/debian'
   components %w(stable)
   distribution node['lsb']['codename']
@@ -117,7 +112,7 @@ node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unle
 
 magic_shell_environment 'DOCKER_HOST' do
   value node['osl-docker']['host']
-  only_if { node['osl-docker']['host'] }
+  not_if { node['osl-docker']['host'].nil? }
 end
 
 magic_shell_environment 'DOCKER_TLS_VERIFY' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,13 +38,8 @@ package 'dirmngr' do
   only_if { node['platform_family'] == 'debian' && node['platform_version'].to_i >= 9 }
 end
 
-apt_repository 'docker-stable' do
-  uri 'https://download.docker.com/linux/debian'
-  components %w(stable)
-  distribution node['lsb']['codename']
-  keyserver 'hkp://p80.pool.sks-keyservers.net:80'
-  key '0EBFCD88'
-  only_if { node['platform_family'] == 'debian' }
+if node['platform_family'] == 'debian'
+  include_recipe 'chef-apt-docker'
 end
 
 apt_preference node['osl-docker']['package']['package_name'] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,11 @@ if node['platform_family'] == 'rhel' && node['kernel']['machine'] != 's390x'
     end
   end
 
+  # Removes the old docker-main repo (replaced by docker-stable)
+  yum_repository 'docker-main' do
+    action :delete
+  end
+
   yum_version_lock node['osl-docker']['package']['package_name'] do
     version node['osl-docker']['package']['version']
     release node['osl-docker']['package_release']
@@ -40,12 +45,15 @@ end
 
 if node['platform_family'] == 'debian'
   include_recipe 'chef-apt-docker'
-end
 
-apt_preference node['osl-docker']['package']['package_name'] do
-  pin "version #{node['osl-docker']['package']['version']}*"
-  pin_priority '1001'
-  only_if { node['platform_family'] == 'debian' }
+  apt_repository 'docker-main' do
+    action :remove
+  end
+
+  apt_preference node['osl-docker']['package']['package_name'] do
+    pin "version #{node['osl-docker']['package']['version']}*"
+    pin_priority '1001'
+  end
 end
 
 docker_installation_tarball 'default' do

--- a/recipes/workstation.rb
+++ b/recipes/workstation.rb
@@ -17,8 +17,4 @@
 # limitations under the License.
 node.override['osl-docker']['host'] = 'tcp://127.0.0.1:2375'
 
-magic_shell_environment 'DOCKER_HOST' do
-  value 'tcp://127.0.0.1:2375'
-end
-
 include_recipe 'osl-docker::default'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,25 +5,25 @@ ChefSpec::Coverage.start! { add_filter 'osl-docker' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.2.1511'
+  version: '7.2.1511',
 }.freeze
 
 DEBIAN_8 = {
   platform: 'debian',
-  version: '8.4'
+  version: '8.4',
 }.freeze
 
 ALL_PLATFORMS = [
   CENTOS_7,
-  DEBIAN_8
+  DEBIAN_8,
 ].freeze
 
 CENTOS_PLATFORMS = [
-  CENTOS_7
+  CENTOS_7,
 ].freeze
 
 DEBIAN_PLATFORMS = [
-  DEBIAN_8
+  DEBIAN_8,
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -239,7 +239,7 @@ describe 'osl-docker::default' do
               components: %w(stable),
               distribution: 'jessie',
               keyserver: 'hkp://p80.pool.sks-keyservers.net:80',
-              key: '0EBFCD88'
+              key: %w(0EBFCD88)
             )
         end
         it do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -60,7 +60,7 @@ describe 'osl-docker::default' do
       context 'DOCKER_HOST set' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|
-            node.set['osl-docker']['host'] = 'tcp://127.0.0.1:2375'
+            node.normal['osl-docker']['host'] = 'tcp://127.0.0.1:2375'
           end.converge(described_recipe)
         end
         it do
@@ -86,7 +86,7 @@ describe 'osl-docker::default' do
       context 'Enable TLS' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|
-            node.set['osl-docker']['tls'] = true
+            node.normal['osl-docker']['tls'] = true
           end.converge(described_recipe)
         end
         it do
@@ -160,7 +160,7 @@ describe 'osl-docker::default' do
             end.converge(described_recipe)
           end
           it do
-            expect(chef_run).to create_yum_repository('docker-main')
+            expect(chef_run).to create_yum_repository('docker-stable')
               .with(
                 baseurl: 'http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/',
                 gpgcheck: false
@@ -174,7 +174,7 @@ describe 'osl-docker::default' do
             end.converge(described_recipe)
           end
           it do
-            expect(chef_run).to_not create_yum_repository('docker-main')
+            expect(chef_run).to_not create_yum_repository('docker-stable')
           end
           %w(yum-docker yum-plugin-versionlock).each do |r|
             it do
@@ -197,13 +197,13 @@ describe 'osl-docker::default' do
           end
         end
         it do
-          expect(chef_run).to create_yum_repository('docker-main')
+          expect(chef_run).to create_yum_repository('docker-stable')
             .with(
-              baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable/',
+              baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable',
               gpgkey: 'https://download.docker.com/linux/centos/gpg'
             )
         end
-        %w(yum-docker yum-plugin-versionlock).each do |r|
+        %w(chef-yum-docker yum-plugin-versionlock).each do |r|
           it do
             expect(chef_run).to include_recipe(r)
           end
@@ -217,10 +217,10 @@ describe 'osl-docker::default' do
         end
         it do
           expect(chef_run.yum_version_lock('docker-ce')).to \
-            notify('yum_repository[docker-main]').to(:makecache).immediately
+            notify('yum_repository[docker-stable]').to(:makecache).immediately
         end
         it do
-          expect(chef_run).to_not add_apt_repository('docker-main')
+          expect(chef_run).to_not add_apt_repository('docker-stable')
         end
         it do
           expect(chef_run).to_not add_apt_preference('docker-ce')
@@ -233,7 +233,7 @@ describe 'osl-docker::default' do
           expect(chef_run).to create_docker_installation_package('default').with(version: '17.09.0')
         end
         it do
-          expect(chef_run).to add_apt_repository('docker-main')
+          expect(chef_run).to add_apt_repository('docker-stable')
             .with(
               uri: 'https://download.docker.com/linux/debian',
               components: %w(stable),
@@ -250,7 +250,7 @@ describe 'osl-docker::default' do
             )
         end
         it do
-          expect(chef_run).to_not include_recipe('yum-docker')
+          expect(chef_run).to_not include_recipe('chef-yum-docker')
         end
         it do
           expect(chef_run).to_not add_yum_version_lock('docker-engine')

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -209,6 +209,9 @@ describe 'osl-docker::default' do
           end
         end
         it do
+          expect(chef_run).to delete_yum_repository('docker-main')
+        end
+        it do
           expect(chef_run).to add_yum_version_lock('docker-ce')
             .with(
               version: '17.09.0.ce',
@@ -237,6 +240,9 @@ describe 'osl-docker::default' do
         end
         it do
           expect(chef_run).to add_apt_repository('docker-stable')
+        end
+        it do
+          expect(chef_run).to remove_apt_repository('docker-main')
         end
         it do
           expect(chef_run).to add_apt_preference('docker-ce')

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -233,14 +233,10 @@ describe 'osl-docker::default' do
           expect(chef_run).to create_docker_installation_package('default').with(version: '17.09.0')
         end
         it do
+          expect(chef_run).to include_recipe('chef-apt-docker')
+        end
+        it do
           expect(chef_run).to add_apt_repository('docker-stable')
-            .with(
-              uri: 'https://download.docker.com/linux/debian',
-              components: %w(stable),
-              distribution: 'jessie',
-              keyserver: 'hkp://p80.pool.sks-keyservers.net:80',
-              key: %w(0EBFCD88)
-            )
         end
         it do
           expect(chef_run).to add_apt_preference('docker-ce')

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -36,7 +36,7 @@ describe 'osl-docker::powerci' do
               '--protocol tcp --source 192.168.6.0/24 --destination-port 2375 --jump ACCEPT',
               '--protocol tcp --source 192.168.6.0/24 --destination-port 2376 --jump ACCEPT',
               '--protocol tcp --source 140.211.168.207/32 --destination-port 2375 --jump ACCEPT',
-              '--protocol tcp --source 140.211.168.207/32 --destination-port 2376 --jump ACCEPT'
+              '--protocol tcp --source 140.211.168.207/32 --destination-port 2376 --jump ACCEPT',
             ]
           )
       end
@@ -45,7 +45,7 @@ describe 'osl-docker::powerci' do
           .with(
             rule: [
               '--protocol tcp --source 192.168.6.0/24 --destination-port 32768:61000 --jump ACCEPT',
-              '--protocol tcp --source 140.211.168.207/32 --destination-port 32768:61000 --jump ACCEPT'
+              '--protocol tcp --source 140.211.168.207/32 --destination-port 32768:61000 --jump ACCEPT',
             ]
           )
       end


### PR DESCRIPTION
Some notes:

* One unit test fails on Chef 12 because of [this](https://github.com/osuosl-cookbooks/osl-docker/pull/22/files#diff-9f91e0135de8f3ef2e8493be0f54648bR242) change. On Chef 13, the key property of apt_repository  can be a String or an Array, but it is [stored as an array](https://github.com/chef/chef/pull/6372/files#diff-a8088b57696c6dfb39ee6d2e03f33d76R36), which means that the property in the test has to be an array. With Chef 12, the key property can not be an Array and is stored as a String...not sure what the best course of action is.

* I replaced the yum-docker cookbook with chef-yum-docker. yum-docker is abandoned (at least AFAICT...the GitHub repo has been deleted) and uses an old version of the yum cookbook that causes deprecation warnings. Hopefully this also fixes some of the dependency conflict issues I've been having with the osl-acme cookbook, which has been a big pain.