### PR TITLE
Tell docker_service not to try an install_method

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,6 +129,8 @@ docker_service 'default' do
   node['osl-docker']['service'].each do |key, value|
     send(key.to_sym, value)
   end
+  # Don't try to install docker twice since we do it above
+  install_method 'none'
   if node['osl-docker']['tls']
     tls_verify true
     tls_ca_cert '/etc/docker/ssl/ca.pem'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -10,7 +10,7 @@ describe 'osl-docker::default' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_docker_service('default')
+        expect(chef_run).to create_docker_service('default').with(install_method: 'none')
       end
       it do
         expect(chef_run).to start_docker_service('default')
@@ -139,6 +139,7 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to create_docker_service('default')
             .with(
+              install_method: 'none',
               tls_verify: true,
               tls_ca_cert: '/etc/docker/ssl/ca.pem',
               tls_server_cert: '/etc/docker/ssl/server.pem',


### PR DESCRIPTION
We install docker using the installation resources directly instead of doing it
in the docker_service resource. This means the recipe tries to install docker
twice which is not good. While we should probably do it via the docker_service
this seems to work well as is. Unfortunately we have a problem on hosts such as
openpower8 which run a mainline kernel and likely confuses the auto installer in
docker_service. For now setting it to none will work around this problem.