### PR TITLE
Update to docker-18.06.2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ suites:
       - recipe[osl-docker::default]
   - name: default_tls
     run_list:
+      - recipe[docker_test]
       - recipe[osl-docker::default]
     attributes:
       osl-docker:

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,7 @@ source 'https://supermarket.chef.io'
 
 solver :ruby, :required
 
+cookbook 'docker_test', path: 'test/cookbooks/docker_test'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,24 +1,24 @@
 case node['platform_family']
 when 'rhel'
-  default['osl-docker']['package']['version'] = '18.06.1.ce'
+  default['osl-docker']['package']['version'] = '18.06.2.ce'
   default['osl-docker']['package_release'] = '3.el7'
   default['osl-docker']['package']['package_version'] =
     "#{default['osl-docker']['package']['version']}-#{default['osl-docker']['package_release']}"
   default['osl-docker']['package']['package_name'] = 'docker-ce'
 when 'debian'
   default['osl-docker']['package']['package_name'] = 'docker-ce'
-  default['osl-docker']['package']['version'] = '18.06.1'
+  default['osl-docker']['package']['version'] = '18.06.2'
 end
 case node['kernel']['machine']
 when 's390x'
-  default['osl-docker']['tarball']['version'] = '18.06.1'
-  default['osl-docker']['tarball']['checksum'] = '4042fc5a00baf9ceb3724b8f1a285bbdda714b0360b4a406fd316ecc6142dee3'
+  default['osl-docker']['tarball']['version'] = '18.06.2'
+  default['osl-docker']['tarball']['checksum'] = 'a061c590785bec5010273eb7592968a65046bb21063e2a387cd8b74d13c6d275'
   default['osl-docker']['tarball']['source'] =
     'https://download.docker.com/linux/static/stable/s390x/docker-' \
     "#{default['osl-docker']['tarball']['version']}-ce.tgz"
 when 'ppc64le'
-  default['osl-docker']['tarball']['version'] = '18.06.1'
-  default['osl-docker']['tarball']['checksum'] = '479083ac0b2bae839782ea53870809b8590f440db5f0bdf1294eac95e1a2ec3b'
+  default['osl-docker']['tarball']['version'] = '18.06.2'
+  default['osl-docker']['tarball']['checksum'] = '9be128dc0da806dca4212da66cb7691f24771a5fd357b30336e4b858263432b3'
   default['osl-docker']['tarball']['source'] =
     'https://download.docker.com/linux/static/stable/ppc64le/docker-' \
     "#{default['osl-docker']['tarball']['version']}-ce.tgz"

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '2.2.1'
 
 depends          'apt', '< 7.0.0'
 depends          'certificate'
-depends          'docker', '~> 4.6.5'
+depends          'docker', '~> 4.9.2'
 depends          'firewall', '>= 4.4.4'
 depends          'systemd', '< 3.0.0'
 depends          'magic_shell'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description      'Installs/Configures osl-docker'
 long_description 'Installs/Configures osl-docker'
 version          '2.2.1'
 
-depends          'apt', '< 7.0.0'
+depends          'apt'
 depends          'certificate'
 depends          'docker', '~> 4.9.2'
 depends          'firewall', '>= 4.4.4'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -152,7 +152,7 @@ describe 'osl-docker::default' do
       case p
       when CENTOS_7
         it do
-          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.1.ce')
+          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.2.ce')
         end
         context 'ppc64le' do
           cached(:chef_run) do
@@ -177,9 +177,9 @@ describe 'osl-docker::default' do
           it do
             expect(chef_run).to create_docker_installation_tarball('default')
               .with(
-                version: '18.06.1',
-                checksum: '479083ac0b2bae839782ea53870809b8590f440db5f0bdf1294eac95e1a2ec3b',
-                source: 'https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.1-ce.tgz'
+                version: '18.06.2',
+                checksum: '9be128dc0da806dca4212da66cb7691f24771a5fd357b30336e4b858263432b3',
+                source: 'https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.2-ce.tgz'
               )
           end
           it do
@@ -209,9 +209,9 @@ describe 'osl-docker::default' do
           it do
             expect(chef_run).to create_docker_installation_tarball('default')
               .with(
-                version: '18.06.1',
-                checksum: '4042fc5a00baf9ceb3724b8f1a285bbdda714b0360b4a406fd316ecc6142dee3',
-                source: 'https://download.docker.com/linux/static/stable/s390x/docker-18.06.1-ce.tgz'
+                version: '18.06.2',
+                checksum: 'a061c590785bec5010273eb7592968a65046bb21063e2a387cd8b74d13c6d275',
+                source: 'https://download.docker.com/linux/static/stable/s390x/docker-18.06.2-ce.tgz'
               )
           end
           it do
@@ -236,7 +236,7 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to add_yum_version_lock('docker-ce')
             .with(
-              version: '18.06.1.ce',
+              version: '18.06.2.ce',
               release: '3.el7'
             )
         end
@@ -255,7 +255,7 @@ describe 'osl-docker::default' do
         end
       when DEBIAN_8
         it do
-          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.1')
+          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.2')
         end
         it do
           expect(chef_run).to_not install_package('dirmngr')
@@ -272,7 +272,7 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to add_apt_preference('docker-ce')
             .with(
-              pin: 'version 18.06.1*',
+              pin: 'version 18.06.2*',
               pin_priority: '1001'
             )
         end
@@ -284,7 +284,7 @@ describe 'osl-docker::default' do
         end
       when DEBIAN_9
         it do
-          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.1')
+          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.2')
         end
         it do
           expect(chef_run).to install_package('dirmngr')
@@ -301,7 +301,7 @@ describe 'osl-docker::default' do
         it do
           expect(chef_run).to add_apt_preference('docker-ce')
             .with(
-              pin: 'version 18.06.1*',
+              pin: 'version 18.06.2*',
               pin_priority: '1001'
             )
         end

--- a/test/cookbooks/docker_test/metadata.rb
+++ b/test/cookbooks/docker_test/metadata.rb
@@ -1,0 +1,2 @@
+name 'docker_test'
+version '0.1.0'

--- a/test/cookbooks/docker_test/recipes/default.rb
+++ b/test/cookbooks/docker_test/recipes/default.rb
@@ -1,0 +1,1 @@
+package 'curl'

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -8,7 +8,7 @@ shared_examples_for 'docker' do |docker_env|
   end
 
   describe command('docker --version') do
-    its(:stdout) { should match(/18\.06\.1-ce/) }
+    its(:stdout) { should match(/18\.06\.2-ce/) }
   end
 
   describe command("#{docker_env} docker ps") do


### PR DESCRIPTION
This addresses CVE-2019-5736 [1] which updates runc [2] to address a critical
vulnerability that allows specially-crafted containers to gain administrative
privileges on the host.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736
[2] https://github.com/docker/docker-ce/releases/tag/v18.06.2-ce

In addition, this also provides the following fixes:

- Revert "Lock apt cookbook to < 7.0.0"
- Fix ServerSpec tests for debian hosts on default-tls suite
- Update to latest upstream docker cookbook version