### PR TITLE
Add support for nvidia-docker

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,13 @@ suites:
   - name: compose
     run_list:
       - recipe[osl-docker::compose]
+  - name: nvidia
+    verifier: inspec
+    run_list:
+      - recipe[osl-docker::nvidia]
+    excludes:
+      - debian-8
+      - debian-9
   - name: powerci
     run_list:
       - recipe[osl-docker::powerci]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,3 @@ default['osl-docker']['tls'] = false
 default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil
 default['osl-docker']['data_bag'] = 'docker'
 default['osl-docker']['client_only'] = false
-default['osl-docker']['nvidia']['driver_version'] = '410.104'
-default['osl-docker']['nvidia']['driver_release'] = '1.el7'
-default['osl-docker']['nvidia']['docker_version'] = '2.0.3'
-default['osl-docker']['nvidia']['docker_release'] = '1.docker18.09.2.ce'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,8 +23,13 @@ when 'ppc64le', 's390x'
   default['osl-docker']['package']['setup_docker_repo'] = false
 end
 default['osl-docker']['service'] = {}
+default['osl-docker']['daemon'] = {}
 default['osl-docker']['prune']['volume_filter'] = []
 default['osl-docker']['tls'] = false
 default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil
 default['osl-docker']['data_bag'] = 'docker'
 default['osl-docker']['client_only'] = false
+default['osl-docker']['nvidia']['driver_version'] = '410.104'
+default['osl-docker']['nvidia']['driver_release'] = '1.el7'
+default['osl-docker']['nvidia']['docker_version'] = '2.0.3'
+default['osl-docker']['nvidia']['docker_release'] = '1.docker18.09.2.ce'

--- a/attributes/nvidia.rb
+++ b/attributes/nvidia.rb
@@ -1,0 +1,10 @@
+default['osl-docker']['nvidia']['version_lock'].tap do |p|
+  p['nvidia-driver']['version'] = '410.104'
+  p['nvidia-driver']['release'] = '1.el7'
+  p['nvidia-docker2']['version'] = '2.0.3'
+  p['nvidia-docker2']['release'] = '1.docker18.09.2.ce'
+  p['cuda-drivers']['version'] = '410.104'
+  p['cuda-drivers']['release'] = '1'
+  p['cuda']['version'] = '10.0.130'
+  p['cuda']['release'] = '1'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,10 +10,13 @@ long_description 'Installs/Configures osl-docker'
 version          '2.3.1'
 
 depends          'apt'
+depends          'build-essential'
 depends          'certificate'
 depends          'docker', '~> 4.9.2'
 depends          'firewall', '>= 4.4.4'
 depends          'magic_shell'
+depends          'yum-epel'
+depends          'yum-nvidia'
 depends          'yum-plugin-versionlock'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -90,6 +90,15 @@ docker_installation_package 'default' do
   notifies :restart, 'docker_service[default]' unless node['osl-docker']['client_only']
 end
 
+directory '/etc/docker'
+
+template '/etc/docker/daemon.json' do
+  variables(
+    config: node['osl-docker']['daemon']
+  )
+  notifies :restart, 'docker_service[default]' unless node['osl-docker']['client_only']
+end
+
 directory '/etc/docker/ssl' do
   owner 'root'
   group 'docker'

--- a/recipes/nvidia.rb
+++ b/recipes/nvidia.rb
@@ -1,0 +1,59 @@
+#
+# Cookbook:: osl-docker
+# Recipe:: nvidia
+#
+# Copyright:: 2019, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+return unless node['platform_family'] == 'rhel'
+
+node.default['osl-docker']['daemon'] = {
+  runtimes: {
+    nvidia: {
+      path: 'nvidia-container-runtime',
+      runtimeArgs: [],
+    },
+  },
+}
+
+include_recipe 'yum-epel'
+include_recipe 'yum-nvidia'
+include_recipe 'build-essential'
+include_recipe 'osl-docker'
+include_recipe 'yum-plugin-versionlock'
+
+%w(
+  dkms-nvidia
+  nvidia-driver
+  nvidia-driver-cuda-libs
+  nvidia-driver-libs
+).each do |p|
+  yum_version_lock p do
+    version node['osl-docker']['nvidia']['driver_version']
+    release node['osl-docker']['nvidia']['driver_release']
+    epoch 3
+  end
+end
+
+yum_version_lock 'nvidia-docker2' do
+  version node['osl-docker']['nvidia']['docker_version']
+  release node['osl-docker']['nvidia']['docker_release']
+end
+
+package 'nvidia-driver' do
+  version "#{node['osl-docker']['nvidia']['driver_version']}-#{node['osl-docker']['nvidia']['driver_release']}"
+end
+
+package 'nvidia-docker2' do
+  version "#{node['osl-docker']['nvidia']['docker_version']}-#{node['osl-docker']['nvidia']['docker_release']}"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,16 +6,19 @@ ChefSpec::Coverage.start! { add_filter 'osl-docker' }
 CENTOS_7 = {
   platform: 'centos',
   version: '7.4.1708',
+  file_cache_path: '/var/chef/cache',
 }.freeze
 
 DEBIAN_8 = {
   platform: 'debian',
   version: '8.10',
+  file_cache_path: '/var/chef/cache',
 }.freeze
 
 DEBIAN_9 = {
   platform: 'debian',
   version: '9.3',
+  file_cache_path: '/var/chef/cache',
 }.freeze
 
 ALL_PLATFORMS = [

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -16,6 +16,23 @@ describe 'osl-docker::client' do
         expect(chef_run).to_not add_magic_shell_environment('DOCKER_HOST')
       end
       it do
+        expect(chef_run).to create_directory('/etc/docker')
+      end
+      it do
+        expect(chef_run).to create_template('/etc/docker/daemon.json')
+          .with(
+            variables: {
+              config: {},
+            }
+          )
+      end
+      it do
+        expect(chef_run).to render_file('/etc/docker/daemon.json').with_content("{\n}")
+      end
+      it do
+        expect(chef_run.template('/etc/docker/daemon.json')).to_not notify('docker_service[default]').to(:restart)
+      end
+      it do
         expect(chef_run).to_not create_directory('/etc/docker/ssl')
       end
       it do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -19,6 +19,23 @@ describe 'osl-docker::default' do
         expect(chef_run).to_not add_magic_shell_environment('DOCKER_HOST')
       end
       it do
+        expect(chef_run).to create_directory('/etc/docker')
+      end
+      it do
+        expect(chef_run).to create_template('/etc/docker/daemon.json')
+          .with(
+            variables: {
+              config: {},
+            }
+          )
+      end
+      it do
+        expect(chef_run).to render_file('/etc/docker/daemon.json').with_content("{\n}")
+      end
+      it do
+        expect(chef_run.template('/etc/docker/daemon.json')).to notify('docker_service[default]').to(:restart)
+      end
+      it do
         expect(chef_run).to_not create_directory('/etc/docker/ssl')
       end
       it do

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -1,0 +1,106 @@
+require_relative '../../spec_helper'
+
+describe 'osl-docker::nvidia' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      case p
+      when CENTOS_7
+        %w(
+          yum-epel
+          yum-nvidia
+          build-essential
+          osl-docker
+          yum-plugin-versionlock
+        ).each do |r|
+          it do
+            expect(chef_run).to include_recipe(r)
+          end
+        end
+
+        %w(
+          dkms-nvidia
+          nvidia-driver
+          nvidia-driver-cuda-libs
+          nvidia-driver-libs
+        ).each do |pkg|
+          it do
+            expect(chef_run).to add_yum_version_lock(pkg)
+              .with(
+                version: '410.104',
+                release: '1.el7',
+                epoch: 3
+              )
+          end
+        end
+
+        it do
+          expect(chef_run).to add_yum_version_lock('nvidia-docker2')
+            .with(
+              version: '2.0.3',
+              release: '1.docker18.09.2.ce'
+            )
+        end
+
+        it do
+          expect(chef_run).to install_package('nvidia-driver').with(version: '410.104-1.el7')
+        end
+
+        it do
+          expect(chef_run).to install_package('nvidia-docker2').with(version: '2.0.3-1.docker18.09.2.ce')
+        end
+        it do
+          expect(chef_run).to create_template('/etc/docker/daemon.json')
+            .with(
+              variables: {
+                config: {
+                  'runtimes' => {
+                    'nvidia' => {
+                      'path' => 'nvidia-container-runtime',
+                      'runtimeArgs' => [],
+                    },
+                  },
+                },
+              }
+            )
+        end
+      when DEBIAN_8, DEBIAN_9
+        %w(
+          yum-epel
+          yum-nvidia
+          build-essential
+          osl-docker
+          yum-plugin-versionlock
+        ).each do |r|
+          it do
+            expect(chef_run).to_not include_recipe(r)
+          end
+        end
+
+        %w(
+          dkms-nvidia
+          nvidia-driver
+          nvidia-driver-cuda-libs
+          nvidia-driver-libs
+        ).each do |pkg|
+          it do
+            expect(chef_run).to_not add_yum_version_lock(pkg)
+          end
+        end
+
+        it do
+          expect(chef_run).to_not install_package('nvidia-driver')
+        end
+
+        it do
+          expect(chef_run).to_not install_package('nvidia-docker2')
+        end
+      end
+    end
+  end
+end

--- a/templates/default/daemon.json.erb
+++ b/templates/default/daemon.json.erb
@@ -1,0 +1,1 @@
+<%= JSON.pretty_generate(@config) %>

--- a/test/integration/client/serverspec/client_spec.rb
+++ b/test/integration/client/serverspec/client_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+describe file('/etc/docker/daemon.json') do
+  its(:content) { should match(/{\n}/) }
+end
+
 describe service('docker') do
   it { should_not be_enabled }
   it { should_not be_running }

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -4,6 +4,10 @@ describe 'docker' do
   it_behaves_like 'docker'
 end
 
+describe file('/etc/docker/daemon.json') do
+  its(:content) { should match(/{\n}/) }
+end
+
 describe cron do
   it { should have_entry('15 * * * * /usr/bin/docker system prune --volumes -f  > /dev/null') }
   it { should have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f  > /dev/null') }

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -2,6 +2,10 @@ require 'serverspec'
 set :backend, :exec
 
 shared_examples_for 'docker' do |docker_env|
+  describe file('/etc/docker') do
+    it { should be_directory }
+  end
+
   describe service('docker') do
     it { should be_enabled }
     it { should be_running }

--- a/test/integration/nvidia/inspec/nvidia_spec.rb
+++ b/test/integration/nvidia/inspec/nvidia_spec.rb
@@ -1,0 +1,23 @@
+# # encoding: utf-8
+
+# Inspec test for recipe osl-docker::nvidia
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/
+describe package('nvidia-driver') do
+  it { should be_installed }
+  its('version') { should eq '410.104-1.el7' }
+end
+
+describe package('nvidia-docker2') do
+  it { should be_installed }
+  its('version') { should eq '2.0.3-1.docker18.09.2.ce' }
+end
+
+describe docker.info do
+  its('Runtimes.nvidia.path') { should eq 'nvidia-container-runtime' }
+end
+
+describe command('nvidia-docker ps') do
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/nvidia/inspec/nvidia_spec.rb
+++ b/test/integration/nvidia/inspec/nvidia_spec.rb
@@ -14,6 +14,11 @@ describe package('nvidia-docker2') do
   its('version') { should eq '2.0.3-1.docker18.09.2.ce' }
 end
 
+describe package('cuda-drivers') do
+  it { should be_installed }
+  its('version') { should eq '410.104-1' }
+end
+
 describe docker.info do
   its('Runtimes.nvidia.path') { should eq 'nvidia-container-runtime' }
 end


### PR DESCRIPTION
This primarily installs the nvidia-docker2 package which pulls in all of the
necessary dependent packages to get nvidia-docker to work. In addition, this
also installs a version pinned version of the nvidia-driver. The version
currently locked is what's needed to test the openpower-gpu1 test host and can
be changed later to a newer version if needed.

Some other changes:
- Management of /etc/docker/daemon.json so that we can completely manage the
  runtime configuration and not rely on the nvidia-docker2 package.