### PR TITLE
Add client recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,9 @@ suites:
         tls: true
     driver_config:
       server_name: default_tls
+  - name: client
+    run_list:
+      - recipe[osl-docker::client]
   - name: compose
     run_list:
       - recipe[osl-docker::compose]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,3 +27,4 @@ default['osl-docker']['prune']['volume_filter'] = []
 default['osl-docker']['tls'] = false
 default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil
 default['osl-docker']['data_bag'] = 'docker'
+default['osl-docker']['client_only'] = false

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook:: osl-docker
+# Recipe:: client
+#
+# Copyright:: 2019, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+node.default['osl-docker']['client_only'] = true
+include_recipe 'osl-docker'

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -1,0 +1,185 @@
+require_relative '../../spec_helper'
+
+describe 'osl-docker::client' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run.docker_service('default')).to do_nothing
+      end
+      it do
+        expect(chef_run).to_not add_magic_shell_environment('DOCKER_HOST')
+      end
+      it do
+        expect(chef_run).to_not create_directory('/etc/docker/ssl')
+      end
+      it do
+        expect(chef_run).to_not create_certificate_manage('server-fauxhai-local')
+      end
+      it do
+        expect(chef_run).to_not create_certificate_manage('client-fauxhai-local')
+      end
+      it do
+        expect(chef_run).to_not add_magic_shell_environment('DOCKER_TLS_VERIFY').with(value: '1')
+      end
+      it do
+        expect(chef_run).to_not add_magic_shell_environment('DOCKER_CERT_PATH').with(value: '/etc/docker/ssl')
+      end
+      it do
+        expect(chef_run.cron('docker_prune_volumes')).to do_nothing
+      end
+      it do
+        expect(chef_run.cron('docker_prune_images')).to do_nothing
+      end
+      it do
+        expect(chef_run).to disable_service('docker')
+      end
+      it do
+        expect(chef_run).to stop_service('docker')
+      end
+      case p
+      when CENTOS_7
+        it do
+          expect(chef_run).to create_docker_installation_package('default').with(version: '18.09.2')
+        end
+        context 'ppc64le' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.automatic['kernel']['machine'] = 'ppc64le'
+            end.converge(described_recipe)
+          end
+          it do
+            expect(chef_run).to create_yum_repository('Docker')
+              .with(
+                baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch',
+                gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+                description: 'Docker Stable repository',
+                gpgcheck: true,
+                enabled: true
+              )
+          end
+        end
+        context 's390x' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(p) do |node|
+              node.automatic['kernel']['machine'] = 's390x'
+            end.converge(described_recipe)
+          end
+          it do
+            expect(chef_run).to create_yum_repository('Docker')
+              .with(
+                baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch',
+                gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+                description: 'Docker Stable repository',
+                gpgcheck: true,
+                enabled: true
+              )
+          end
+        end
+        it do
+          expect(chef_run).to include_recipe('yum-plugin-versionlock')
+        end
+        %w(
+          docker-main
+          docker-stable
+          docker-edge
+          docker-test
+        ).each do |r|
+          it do
+            expect(chef_run).to delete_yum_repository(r)
+          end
+        end
+        it do
+          expect(chef_run).to add_yum_version_lock('docker-ce')
+            .with(
+              version: '18.09.2',
+              release: '3.el7'
+            )
+        end
+        it do
+          expect(chef_run).to add_yum_version_lock('docker-ce-cli')
+            .with(
+              version: '18.09.2',
+              release: '3.el7'
+            )
+        end
+        it do
+          expect(chef_run).to_not install_package('dirmgr')
+        end
+      when DEBIAN_8
+        it do
+          expect(chef_run).to create_docker_installation_package('default').with(version: '18.06.3')
+        end
+        it do
+          expect(chef_run).to_not install_package('dirmngr')
+        end
+        %w(
+          docker-main
+          docker-stable
+          docker-edge
+          docker-test
+        ).each do |r|
+          it do
+            expect(chef_run).to remove_apt_repository(r)
+          end
+        end
+        it do
+          expect(chef_run).to add_apt_preference('docker-ce')
+            .with(
+              pin: 'version 18.06.3*',
+              pin_priority: '1001'
+            )
+        end
+        it do
+          expect(chef_run).to add_apt_preference('docker-ce-cli')
+            .with(
+              pin: 'version 18.06.3*',
+              pin_priority: '1001'
+            )
+        end
+        it do
+          expect(chef_run).to_not add_yum_version_lock('docker-ce')
+        end
+        it do
+          expect(chef_run).to_not add_yum_version_lock('docker-ce-cli')
+        end
+      when DEBIAN_9
+        it do
+          expect(chef_run).to create_docker_installation_package('default').with(version: '5:18.09.2')
+        end
+        it do
+          expect(chef_run).to install_package('dirmngr')
+        end
+        %w(
+          docker-main
+          docker-stable
+          docker-edge
+          docker-test
+        ).each do |r|
+          it do
+            expect(chef_run).to remove_apt_repository(r)
+          end
+        end
+        it do
+          expect(chef_run).to add_apt_preference('docker-ce')
+            .with(
+              pin: 'version 5:18.09.2*',
+              pin_priority: '1001'
+            )
+        end
+        it do
+          expect(chef_run).to add_apt_preference('docker-ce-cli')
+            .with(
+              pin: 'version 5:18.09.2*',
+              pin_priority: '1001'
+            )
+        end
+      end
+    end
+  end
+end

--- a/test/integration/client/serverspec/client_spec.rb
+++ b/test/integration/client/serverspec/client_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe service('docker') do
+  it { should_not be_enabled }
+  it { should_not be_running }
+end
+
+%w(docker dockerd).each do |cmd|
+  describe command("#{cmd} --version") do
+    if os[:family] == 'debian' && os[:release].to_i == 8
+      its(:stdout) { should match(/18\.06\.3/) }
+    else
+      its(:stdout) { should match(/18\.09\.2/) }
+    end
+  end
+end
+
+describe command('docker ps') do
+  its(:exit_status) { should eq 1 }
+end
+
+describe cron do
+  it { should_not have_entry('15 * * * * /usr/bin/docker system prune --volumes -f  > /dev/null') }
+  it { should_not have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f  > /dev/null') }
+end


### PR DESCRIPTION
In some cases, we only want to have the docker cli installed and not the
service. One example of this is on Jenkins servers where we don't want the
docker daemon running. Instead we want to run them on worker nodes so we can
scale it better.

This just adds support within the default recipe via an attribute. For ease of
use, adding of the client recipe just sets this attribute so we can simply add
it in a run list where we need it.