### PR TITLE
Enable builtin prometheus metrics in docker

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,11 @@ when 'ppc64le', 's390x'
   default['osl-docker']['package']['setup_docker_repo'] = false
 end
 default['osl-docker']['service'] = {}
-default['osl-docker']['daemon'] = {}
+default['osl-docker']['daemon'] =
+  {
+    'metrics-addr' => '0.0.0.0:9323',
+    'experimental' => true,
+  }
 default['osl-docker']['prune']['volume_filter'] = []
 default['osl-docker']['tls'] = false
 default['osl-docker']['host'] = node['osl-docker']['tls'] ? 'tcp://127.0.0.1:2376' : nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -96,7 +96,8 @@ template '/etc/docker/daemon.json' do
   variables(
     config: node['osl-docker']['daemon']
   )
-  notifies :restart, 'docker_service[default]' unless node['osl-docker']['client_only']
+  not_if { node['osl-docker']['client_only'] }
+  notifies :restart, 'docker_service[default]'
 end
 
 directory '/etc/docker/ssl' do

--- a/recipes/nvidia.rb
+++ b/recipes/nvidia.rb
@@ -17,12 +17,10 @@
 # limitations under the License.
 return unless node['platform_family'] == 'rhel'
 
-node.default['osl-docker']['daemon'] = {
-  runtimes: {
-    nvidia: {
-      path: 'nvidia-container-runtime',
-      runtimeArgs: [],
-    },
+node.default['osl-docker']['daemon']['runtimes'] = {
+  nvidia: {
+    path: 'nvidia-container-runtime',
+    runtimeArgs: [],
   },
 }
 

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -19,18 +19,7 @@ describe 'osl-docker::client' do
         expect(chef_run).to create_directory('/etc/docker')
       end
       it do
-        expect(chef_run).to create_template('/etc/docker/daemon.json')
-          .with(
-            variables: {
-              config: {},
-            }
-          )
-      end
-      it do
-        expect(chef_run).to render_file('/etc/docker/daemon.json').with_content("{\n}")
-      end
-      it do
-        expect(chef_run.template('/etc/docker/daemon.json')).to_not notify('docker_service[default]').to(:restart)
+        expect(chef_run).to_not create_template('/etc/docker/daemon.json')
       end
       it do
         expect(chef_run).to_not create_directory('/etc/docker/ssl')

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -25,12 +25,19 @@ describe 'osl-docker::default' do
         expect(chef_run).to create_template('/etc/docker/daemon.json')
           .with(
             variables: {
-              config: {},
+              config: {
+                'metrics-addr' => '0.0.0.0:9323',
+                'experimental' => true,
+              },
             }
           )
       end
       it do
-        expect(chef_run).to render_file('/etc/docker/daemon.json').with_content("{\n}")
+        expect(chef_run).to render_file('/etc/docker/daemon.json')
+          .with_content('{
+  "metrics-addr": "0.0.0.0:9323",
+  "experimental": true
+}')
       end
       it do
         expect(chef_run.template('/etc/docker/daemon.json')).to notify('docker_service[default]').to(:restart)

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -106,6 +106,8 @@ describe 'osl-docker::nvidia' do
             .with(
               variables: {
                 config: {
+                  'metrics-addr' => '0.0.0.0:9323',
+                  'experimental' => true,
                   'runtimes' => {
                     'nvidia' => {
                       'path' => 'nvidia-container-runtime',

--- a/test/integration/client/serverspec/client_spec.rb
+++ b/test/integration/client/serverspec/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe file('/etc/docker/daemon.json') do
-  its(:content) { should match(/{\n}/) }
+  it { should_not exist }
 end
 
 describe service('docker') do

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -5,10 +5,24 @@ describe 'docker' do
 end
 
 describe file('/etc/docker/daemon.json') do
-  its(:content) { should match(/{\n}/) }
+  its(:content) do
+    should match(/{
+  "metrics-addr": "0.0.0.0:9323",
+  "experimental": true
+}/)
+  end
 end
 
 describe cron do
   it { should have_entry('15 * * * * /usr/bin/docker system prune --volumes -f  > /dev/null') }
   it { should have_entry('45 2 * * 0 /usr/bin/docker system prune -a -f  > /dev/null') }
+end
+
+describe port(9323) do
+  it { should be_listening }
+end
+
+describe command('curl http://localhost:9323/metrics') do
+  its(:stdout) { should match(/^engine_daemon_engine_info.*/) }
+  its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
Docker has a builtin metrics feature which prometheus can use. This enables the port. The firewall will be configured elsewhere.

[1] https://docs.docker.com/config/thirdparty/prometheus/