### PR TITLE
Update nvidia-driver to 418.87.00 and fix package name

### DIFF
--- a/attributes/nvidia.rb
+++ b/attributes/nvidia.rb
@@ -1,5 +1,5 @@
 default['osl-docker']['nvidia']['version_lock'].tap do |p|
-  p['nvidia-driver']['version'] = '410.104'
+  p['nvidia-driver']['version'] = '418.87.00'
   p['nvidia-driver']['release'] = '1.el7'
   p['nvidia-docker2']['version'] = '2.0.3'
   p['nvidia-docker2']['release'] = '1.docker18.09.2.ce'

--- a/recipes/nvidia.rb
+++ b/recipes/nvidia.rb
@@ -39,6 +39,12 @@ makecache_file = ::File.join(Chef::Config[:file_cache_path], 'makecache-cuda')
   nvidia-driver-cuda
   nvidia-driver-cuda-libs
   nvidia-driver-devel
+  nvidia-driver-latest-dkms
+  nvidia-driver-latest-dkms-cuda
+  nvidia-driver-latest-dkms-cuda-libs
+  nvidia-driver-latest-dkms-devel
+  nvidia-driver-latest-dkms-NvFBCOpenGL
+  nvidia-driver-latest-dkms-NVML
   nvidia-driver-libs
   nvidia-driver-NvFBCOpenGL
   nvidia-driver-NVML
@@ -85,4 +91,4 @@ file makecache_file do
   action :delete
 end
 
-package %w(nvidia-driver cuda-drivers nvidia-docker2)
+package %w(nvidia-driver-latest-dkms cuda-drivers nvidia-docker2)

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -33,6 +33,12 @@ describe 'osl-docker::nvidia' do
           nvidia-driver-cuda
           nvidia-driver-cuda-libs
           nvidia-driver-devel
+          nvidia-driver-latest-dkms
+          nvidia-driver-latest-dkms-cuda
+          nvidia-driver-latest-dkms-cuda-libs
+          nvidia-driver-latest-dkms-devel
+          nvidia-driver-latest-dkms-NvFBCOpenGL
+          nvidia-driver-latest-dkms-NVML
           nvidia-driver-libs
           nvidia-driver-NvFBCOpenGL
           nvidia-driver-NVML
@@ -46,7 +52,7 @@ describe 'osl-docker::nvidia' do
           it do
             expect(chef_run).to add_yum_version_lock(pkg)
               .with(
-                version: '410.104',
+                version: '418.87.00',
                 release: '1.el7',
                 epoch: 3
               )
@@ -98,7 +104,7 @@ describe 'osl-docker::nvidia' do
         end
 
         it do
-          expect(chef_run).to install_package(%w(nvidia-driver cuda-drivers nvidia-docker2))
+          expect(chef_run).to install_package(%w(nvidia-driver-latest-dkms cuda-drivers nvidia-docker2))
         end
 
         it do
@@ -156,6 +162,12 @@ describe 'osl-docker::nvidia' do
           nvidia-driver-cuda
           nvidia-driver-cuda-libs
           nvidia-driver-devel
+          nvidia-driver-latest-dkms
+          nvidia-driver-latest-dkms-cuda
+          nvidia-driver-latest-dkms-cuda-libs
+          nvidia-driver-latest-dkms-devel
+          nvidia-driver-latest-dkms-NvFBCOpenGL
+          nvidia-driver-latest-dkms-NVML
           nvidia-driver-libs
           nvidia-driver-NvFBCOpenGL
           nvidia-driver-NVML
@@ -172,7 +184,7 @@ describe 'osl-docker::nvidia' do
         end
 
         it do
-          expect(chef_run).to_not install_package(%w(nvidia-driver cuda-drivers nvidia-docker2))
+          expect(chef_run).to_not install_package(%w(nvidia-driver-latest-dkms cuda-drivers nvidia-docker2))
         end
       end
     end

--- a/test/integration/nvidia/inspec/nvidia_spec.rb
+++ b/test/integration/nvidia/inspec/nvidia_spec.rb
@@ -4,9 +4,9 @@
 
 # The Inspec reference, with examples and extensive documentation, can be
 # found at http://inspec.io/docs/reference/resources/
-describe package('nvidia-driver') do
+describe package('nvidia-driver-latest-dkms') do
   it { should be_installed }
-  its('version') { should eq '410.104-1.el7' }
+  its('version') { should eq '418.87.00-1.el7' }
 end
 
 describe package('nvidia-docker2') do


### PR DESCRIPTION
The upstream Nvidia repository has changed the name of the driver RPM from
nvidia-driver to nvidia-driver-latest-dkms and obsoleted the old package. This
causes the driver to be automatically updated on our systems which is not
intended [1]. This should resolve that by doing the following:

- Add/Update package name to nvidia-driver-latest-dkms
- Update version to 418.87.00 since it was already upgraded on the production
  system

[1] https://support.osuosl.org/Ticket/Display.html?id=30781