### PR TITLE
CentOS 8 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,6 +34,7 @@ suites:
     run_list:
       - recipe[osl-docker::nvidia]
     excludes:
+      - centos-8 # TODO: Add back after we upgrade to version 440 or later
       - debian-9
   - name: powerci
     run_list:
@@ -52,3 +53,4 @@ suites:
       - recipe[osl-docker::workstation]
     excludes:
       - centos-7
+      - centos-8

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,6 @@ solver :ruby, :required
 
 cookbook 'docker_test', path: 'test/cookbooks/docker_test'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
+cookbook 'yum-plugin-versionlock', github: 'ramereth/chef-yum-plugin-versionlock', branch: 'centos-8'
 
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,8 @@ when 'debian'
   default['osl-docker']['package']['package_version'] = '5:18.09.2~3-0~debian-stretch'
 end
 case node['kernel']['machine']
+when 'x86_64'
+  default['osl-docker']['package']['setup_docker_repo'] = false if node['platform_version'].to_i >= 8
 when 'ppc64le', 's390x'
   default['osl-docker']['package']['setup_docker_repo'] = false
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,5 +18,6 @@ depends          'yum-epel'
 depends          'yum-nvidia'
 depends          'yum-plugin-versionlock'
 
+supports         'centos', '~> 8.0'
 supports         'centos', '~> 7.0'
 supports         'debian', '~> 9.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,12 +34,14 @@ if node['platform_family'] == 'rhel'
     version node['osl-docker']['package']['version']
     release node['osl-docker']['package_release']
     epoch 1
+    action :update
   end
 
   yum_version_lock node['osl-docker']['package']['package_name'] do
     version node['osl-docker']['package']['version']
     release node['osl-docker']['package_release']
     epoch 3
+    action :update
   end
 
   # Use our docker repo for ppc64le & s390x
@@ -50,6 +52,19 @@ if node['platform_family'] == 'rhel'
     gpgcheck true
     enabled true
     only_if { %w(ppc64le s390x).include?(node['kernel']['machine']) }
+  end
+
+  # TODO: Use CentOS 7 repo on CentOS 8 until upstream has created the repo
+  yum_repository 'Docker' do
+    baseurl 'https://download.docker.com/linux/centos/7/x86_64/stable'
+    gpgkey 'https://download.docker.com/linux/centos/gpg'
+    description 'Docker Stable repository'
+    gpgcheck true
+    enabled true
+    # Enable all rpms to workaround modularity issue:
+    # https://forums.docker.com/t/yum-repo-for-centos-8/81884/8
+    options(module_hotfixes: true)
+    only_if { node['platform_version'].to_i >= 8 && node['kernel']['machine'] == 'x86_64' }
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,29 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+CENTOS_8 = {
+  platform: 'centos',
+  version: '8',
+}.freeze
+
 CENTOS_7 = {
   platform: 'centos',
   version: '7',
-  file_cache_path: '/var/chef/cache',
 }.freeze
 
 DEBIAN_9 = {
   platform: 'debian',
   version: '9',
-  file_cache_path: '/var/chef/cache',
 }.freeze
 
 ALL_PLATFORMS = [
+  CENTOS_8,
   CENTOS_7,
   DEBIAN_9,
 ].freeze
 
 CENTOS_PLATFORMS = [
+  CENTOS_8,
   CENTOS_7,
 ].freeze
 
@@ -28,4 +33,5 @@ DEBIAN_PLATFORMS = [
 
 RSpec.configure do |config|
   config.log_level = :warn
+  config.file_cache_path = '/var/chef/cache'
 end

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -101,14 +101,14 @@ describe 'osl-docker::client' do
           end
         end
         it do
-          expect(chef_run).to add_yum_version_lock('docker-ce')
+          expect(chef_run).to update_yum_version_lock('docker-ce')
             .with(
               version: '18.09.2',
               release: '3.el7'
             )
         end
         it do
-          expect(chef_run).to add_yum_version_lock('docker-ce-cli')
+          expect(chef_run).to update_yum_version_lock('docker-ce-cli')
             .with(
               version: '18.09.2',
               release: '3.el7'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -174,7 +174,20 @@ describe 'osl-docker::default' do
         end
       end
       case p
-      when CENTOS_7
+      when CENTOS_7, CENTOS_8
+        if p == CENTOS_8
+          it do
+            expect(chef_run).to create_yum_repository('Docker')
+              .with(
+                baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable',
+                gpgkey: 'https://download.docker.com/linux/centos/gpg',
+                description: 'Docker Stable repository',
+                gpgcheck: true,
+                enabled: true,
+                options: { module_hotfixes: true }
+              )
+          end
+        end
         it do
           expect(chef_run).to create_docker_installation_package('default').with(version: '18.09.2')
         end
@@ -226,14 +239,14 @@ describe 'osl-docker::default' do
           end
         end
         it do
-          expect(chef_run).to add_yum_version_lock('docker-ce')
+          expect(chef_run).to update_yum_version_lock('docker-ce')
             .with(
               version: '18.09.2',
               release: '3.el7'
             )
         end
         it do
-          expect(chef_run).to add_yum_version_lock('docker-ce-cli')
+          expect(chef_run).to update_yum_version_lock('docker-ce-cli')
             .with(
               version: '18.09.2',
               release: '3.el7'

--- a/test/integration/default_tls/inspec/tls_spec.rb
+++ b/test/integration/default_tls/inspec/tls_spec.rb
@@ -3,7 +3,8 @@ require_relative '../../helpers/inspec/docker_helper.rb'
 docker_env = 'DOCKER_HOST="tcp://127.0.0.1:2376" DOCKER_CERT_PATH="/etc/docker/ssl" DOCKER_TLS_VERIFY="1"'
 curl_docker = 'curl -v https://127.0.0.1:2376/images/json ' \
               '--cert /etc/docker/ssl/cert.pem --key /etc/docker/ssl/key.pem --cacert /etc/docker/ssl/ca.pem'
-operating_system = os[:family]
+operating_system = os.family
+release = os.release.to_i
 
 inspec_docker?(docker_env)
 
@@ -12,12 +13,12 @@ describe port(2376) do
 end
 
 describe command(curl_docker) do
-  its('stderr') { should match(/client certificate from file\n.*subject: CN=client/) } if operating_system == 'redhat'
   its('stderr') { should match(/Server certificate:\n.*subject: CN=localhost/) }
   its('stderr') { should match(/Server: Docker/) }
   its('stdout') { should match(/\[.*\]/) }
   its('stderr') { should match(%r{HTTP/1.1 200 OK}) }
-  if operating_system == 'redhat'
+  if operating_system == 'redhat' && release < 8
+    its('stderr') { should match(/client certificate from file\n.*subject: CN=client/) }
     its('stderr') do
       should match(/issuer: E=dnsadmin@osuosl.org,CN=localhost,O=OSU Open Source Lab,L=Corvallis,ST=Oregon,C=US/)
     end


### PR DESCRIPTION
This adds CentOS 8 support with the following adjustments:

- Use CentOS 7 repository with module_hotfixes enabled to work around modularity
  issues [1]
- Use update action for yum_version_lock
- Skip adding support to nvidia recipe until we upgrade the driver
- Updates to various tests

[1] https://forums.docker.com/t/yum-repo-for-centos-8/81884/8

~~**NOTE: This depends on this [PR](https://github.com/karnauskas/chef-yum-plugin-versionlock/pull/14) to be merged upstream.**~~ Going ahead and pushing this onto our Chef Server.