### PR TITLE
Include firewall::docker in default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,6 +94,7 @@ if node['platform_family'] == 'debian'
   end
 end
 
+include_recipe 'firewall::docker'
 include_recipe 'firewall::prometheus'
 
 firewall_prometheus 'docker_exporter' do

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -21,7 +21,6 @@ node.default['osl-docker']['tls'] = true
 node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2376'
 
 include_recipe 'osl-docker::default'
-include_recipe 'firewall::docker'
 
 # docker_volume resource does not have support for labels
 execute 'docker volume create --label preserve=true ccache' do

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -22,7 +22,6 @@ node.default['firewall']['docker']['range']['4'] = %w(192.168.6.0/24 140.211.168
 node.default['firewall']['docker']['expose_ports'] = true
 
 include_recipe 'osl-docker::default'
-include_recipe 'firewall::docker'
 
 # docker_volume resource does not have support for labels
 execute 'docker volume create --label preserve=true ccache' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,8 +9,10 @@ describe 'osl-docker::default' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to include_recipe 'firewall::prometheus'
+      %w(firewall::docker firewall::prometheus).each do |r|
+        it do
+          expect(chef_run).to include_recipe r
+        end
       end
       it do
         expect(chef_run).to create_firewall_prometheus('docker_exporter').with(port: 9323)


### PR DESCRIPTION
This should resolve some ongoing issues we have on hosts when the iptables
service gets restarted and some needed rules are not there.