### PR TITLE
Remove restarting docker service on package upgrades

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -106,7 +106,6 @@ docker_installation_package 'default' do
     send(key.to_sym, value)
   end
   action :create
-  notifies :restart, 'docker_service[default]' unless node['osl-docker']['client_only']
 end
 
 directory '/etc/docker'


### PR DESCRIPTION
There's an issue with Chef on CentOS 8 where it tries to install docker on every
chef run. This causes the docker daemon to always be restarted which can
cause problems for users.