### PR TITLE
Enable log rotation for containers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetChefVersion: 16.latest
-ChefModernize/FoodcriticComments:
+Chef/Modernize/FoodcriticComments:
   Enabled: true
-ChefStyle/CopyrightCommentFormat:
+Chef/Style/CopyrightCommentFormat:
   Enabled: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default['osl-docker']['daemon'] =
   {
     'metrics-addr' => '0.0.0.0:9323',
     'experimental' => true,
+    'log-opts' => {
+      'max-size' => '100m',
+      'max-file' => '10',
+    },
   }
 default['osl-docker']['prune']['volume_filter'] = []
 default['osl-docker']['tls'] = false

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -36,6 +36,10 @@ describe 'osl-docker::default' do
               config: {
                 'metrics-addr' => '0.0.0.0:9323',
                 'experimental' => true,
+                'log-opts' => {
+                  'max-size' => '100m',
+                  'max-file' => '10',
+                },
               },
             }
           )
@@ -44,7 +48,11 @@ describe 'osl-docker::default' do
         expect(chef_run).to render_file('/etc/docker/daemon.json')
           .with_content('{
   "metrics-addr": "0.0.0.0:9323",
-  "experimental": true
+  "experimental": true,
+  "log-opts": {
+    "max-size": "100m",
+    "max-file": "10"
+  }
 }')
       end
       it do

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -143,6 +143,10 @@ describe 'osl-docker::nvidia' do
                 config: {
                   'metrics-addr' => '0.0.0.0:9323',
                   'experimental' => true,
+                  'log-opts' => {
+                    'max-size' => '100m',
+                    'max-file' => '10',
+                  },
                   'runtimes' => {
                     'nvidia' => {
                       'path' => 'nvidia-container-runtime',

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,10 +1,12 @@
-require_relative '../../helpers/inspec/docker_helper.rb'
+require_relative '../../helpers/inspec/docker_helper'
 
 inspec_docker?
 
 describe json('/etc/docker/daemon.json') do
   its('metrics-addr') { should cmp '0.0.0.0:9323' }
   its('experimental') { should cmp 'true' }
+  its(%w(log-opts max-size)) { should cmp '100m' }
+  its(%w(log-opts max-file)) { should cmp '10' }
 end
 
 describe crontab.where { command =~ /docker system prune --volumes/ } do

--- a/test/integration/default_tls/inspec/tls_spec.rb
+++ b/test/integration/default_tls/inspec/tls_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helpers/inspec/docker_helper.rb'
+require_relative '../../helpers/inspec/docker_helper'
 
 docker_env = 'DOCKER_HOST="tcp://127.0.0.1:2376" DOCKER_CERT_PATH="/etc/docker/ssl" DOCKER_TLS_VERIFY="1"'
 curl_docker = 'curl -v https://127.0.0.1:2376/images/json ' \

--- a/test/integration/nvidia/inspec/nvidia_spec.rb
+++ b/test/integration/nvidia/inspec/nvidia_spec.rb
@@ -1,5 +1,3 @@
-# # encoding: utf-8
-
 # Inspec test for recipe osl-docker::nvidia
 
 # The Inspec reference, with examples and extensive documentation, can be

--- a/test/integration/powerci/inspec/powerci_spec.rb
+++ b/test/integration/powerci/inspec/powerci_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helpers/inspec/docker_helper.rb'
+require_relative '../../helpers/inspec/docker_helper'
 
 inspec_docker?('DOCKER_HOST="tcp://0.0.0.0:2375"')
 

--- a/test/integration/workstation/inspec/workstation_spec.rb
+++ b/test/integration/workstation/inspec/workstation_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helpers/inspec/docker_helper.rb'
+require_relative '../../helpers/inspec/docker_helper'
 
 inspec_docker?('DOCKER_HOST="tcp://127.0.0.1:2375"')
 


### PR DESCRIPTION
This will ensure that containers shouldn't fill up the disk with just logs.

This should also resolve disk space issues with app2.
