### PR TITLE
Enable live restore globally

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -101,6 +101,7 @@ certificate_manage "client-#{node['fqdn'].tr('.', '-')}" do
   only_if { node['osl-docker']['tls'] }
 end
 
+node.default['osl-docker']['service']['misc_opts'] = '--live-restore'
 node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
 node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -47,6 +47,8 @@ describe 'osl-docker::default' do
 
       it do
         expect(chef_run).to create_docker_service('default').with(
+          host: %w(unix:///var/run/docker.sock),
+          misc_opts: '--live-restore',
           install_method: 'none'
         )
       end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../helpers/inspec/docker_helper'
 
 inspec_docker?
 
+describe docker.info do
+  its('LiveRestoreEnabled') { should eq true }
+end
+
 describe json('/etc/docker/daemon.json') do
   its('metrics-addr') { should cmp '0.0.0.0:9323' }
   its('experimental') { should cmp 'true' }


### PR DESCRIPTION
This will allow us to restart the docker daemon without bringing containers down (such as when upgrading).

Signed-off-by: Lance Albertson <lance@osuosl.org>
