### PR TITLE
Various fixes for nvidia-docker

### DIFF
--- a/recipes/nvidia.rb
+++ b/recipes/nvidia.rb
@@ -86,6 +86,7 @@ yum_version_lock 'nvidia-docker2' do
   version version_lock['nvidia-docker2']['version']
   release version_lock['nvidia-docker2']['release']
   notifies :touch, "file[#{makecache_file}]", :immediately
+  action :remove
 end
 
 yum_version_lock 'cuda' do
@@ -95,7 +96,7 @@ yum_version_lock 'cuda' do
 end
 
 # Exclude any versions that conflict with what we want
-%w(440).each do |ver|
+%w(440 450 455 460 465 470).each do |ver|
   [
     "nvidia-driver-branch-#{ver}",
     "nvidia-driver-branch-#{ver}-cuda",

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -84,7 +84,7 @@ describe 'osl-docker::nvidia' do
         end
 
         it do
-          expect(chef_run).to add_yum_version_lock('nvidia-docker2')
+          expect(chef_run).to remove_yum_version_lock('nvidia-docker2')
             .with(
               version: '2.0.3',
               release: '1.docker18.09.2.ce'
@@ -98,7 +98,7 @@ describe 'osl-docker::nvidia' do
               release: '1'
             )
         end
-        %w(440).each do |ver|
+        %w(440 450 455 460 465 470).each do |ver|
           [
             "nvidia-driver-branch-#{ver}",
             "nvidia-driver-branch-#{ver}-cuda",

--- a/test/integration/nvidia/inspec/nvidia_spec.rb
+++ b/test/integration/nvidia/inspec/nvidia_spec.rb
@@ -10,7 +10,6 @@ end
 
 describe package('nvidia-docker2') do
   it { should be_installed }
-  its('version') { should eq '2.0.3-1.docker18.09.2.ce' }
 end
 
 describe package('cuda-drivers') do


### PR DESCRIPTION
This removes the version lock on `nvidia-docker2` now that we install the latest docker from upstream. Also add new versions of the driver to exclude so that yum works properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>
