### PR TITLE
Fixed idempotency errors with the client recipe

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,7 +7,7 @@ provisioner:
   data_bags_path: test/integration/data_bags
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   enforce_idempotency: true
-  multiple_converge: 2
+  multiple_converge: 3
   deprecations_as_errors: true
   attributes:
     osl-selinux:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,7 +7,7 @@ provisioner:
   data_bags_path: test/integration/data_bags
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   enforce_idempotency: true
-  multiple_converge: 3
+  multiple_converge: 2
   deprecations_as_errors: true
   attributes:
     osl-selinux:
@@ -29,6 +29,8 @@ suites:
         tls: true
     driver_config:
       server_name: default_tls
+    provisioner:
+      multiple_converge: 3
   - name: client
     run_list:
       - recipe[osl-docker::client]
@@ -52,6 +54,8 @@ suites:
       - recipe[osl-docker::ibmz_ci]
     driver_config:
       server_name: ibmz_ci
+    provisioner:
+      multiple_converge: 3
     excludes:
       - debian-10
   - name: workstation

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,12 +75,10 @@ docker_service 'default' do
   end
   if node['osl-docker']['client_only']
     action [:create, :stop]
+  elsif !node['osl-docker']['tls'] || ::File.exist?('/etc/docker/ssl/key.pem')
+    action [:create, :start]
   else
-    if !node['osl-docker']['tls'] || ::File.exist?('/etc/docker/ssl/key.pem')
-      action [:create, :start]
-    else
-      action [:create]
-    end
+    action [:create]
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,7 +66,6 @@ docker_service 'default' do
   action :create
 end
 
-
 directory '/etc/docker'
 
 template '/etc/docker/daemon.json' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,12 +57,31 @@ osl_firewall_port 'docker_exporter' do
   ports %w(9323)
 end
 
+node.default['osl-docker']['service']['misc_opts'] = '--live-restore'
+node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
+node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?
+
 docker_service 'default' do
   node['osl-docker']['service'].each do |key, value|
     send(key.to_sym, value)
   end
-  install_method 'auto'
-  action :create
+  if node['osl-docker']['tls'] && ::File.exist?('/etc/docker/ssl/key.pem')
+    tls_verify true
+    tls_ca_cert '/etc/docker/ssl/ca.pem'
+    tls_server_cert '/etc/docker/ssl/server.pem'
+    tls_server_key '/etc/docker/ssl/server-key.pem'
+    tls_client_cert '/etc/docker/ssl/cert.pem'
+    tls_client_key '/etc/docker/ssl/key.pem'
+  end
+  if node['osl-docker']['client_only']
+    action [:create, :stop]
+  else
+    if !node['osl-docker']['tls'] || ::File.exist?('/etc/docker/ssl/key.pem')
+      action [:create, :start]
+    else
+      action [:create]
+    end
+  end
 end
 
 directory '/etc/docker'
@@ -81,6 +100,7 @@ directory '/etc/docker/ssl' do
   mode '0750'
   recursive true
   only_if { node['osl-docker']['tls'] }
+  notifies :restart, 'docker_service[default]'
 end
 
 certificate_manage "server-#{node['fqdn'].tr('.', '-')}" do
@@ -106,11 +126,8 @@ certificate_manage "client-#{node['fqdn'].tr('.', '-')}" do
   group 'docker'
   create_subfolders false
   only_if { node['osl-docker']['tls'] }
+  notifies :restart, 'docker_service[default]'
 end
-
-node.default['osl-docker']['service']['misc_opts'] = '--live-restore'
-node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
-node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?
 
 if node['osl-docker']['host'] # use if instead of not_if to fix nil value validation
   osl_shell_environment 'DOCKER_HOST' do
@@ -121,32 +138,13 @@ end
 osl_shell_environment 'DOCKER_TLS_VERIFY' do
   value '1'
   only_if { node['osl-docker']['tls'] }
+  notifies :restart, 'docker_service[default]'
 end
 
 osl_shell_environment 'DOCKER_CERT_PATH' do
   value '/etc/docker/ssl'
   only_if { node['osl-docker']['tls'] }
-end
-
-docker_service 'default' do
-  node['osl-docker']['service'].each do |key, value|
-    send(key.to_sym, value)
-  end
-  # Don't try to install docker twice since we do it above
-  install_method 'none'
-  if node['osl-docker']['tls']
-    tls_verify true
-    tls_ca_cert '/etc/docker/ssl/ca.pem'
-    tls_server_cert '/etc/docker/ssl/server.pem'
-    tls_server_key '/etc/docker/ssl/server-key.pem'
-    tls_client_cert '/etc/docker/ssl/cert.pem'
-    tls_client_key '/etc/docker/ssl/key.pem'
-  end
-  if node['osl-docker']['client_only']
-    action [:stop]
-  else
-    action [:start]
-  end
+  notifies :restart, 'docker_service[default]'
 end
 
 volume_filter = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,7 +57,15 @@ osl_firewall_port 'docker_exporter' do
   ports %w(9323)
 end
 
-docker_installation_package 'default'
+docker_service 'default' do
+  node['osl-docker']['service'].each do |key, value|
+    send(key.to_sym, value)
+  end
+  # Don't try to install docker twice since we do it above
+  install_method 'auto'
+  action :create
+end
+
 
 directory '/etc/docker'
 
@@ -139,7 +147,7 @@ docker_service 'default' do
   if node['osl-docker']['client_only']
     action [:stop]
   else
-    action [:create, :start]
+    action [:start]
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,7 +61,6 @@ docker_service 'default' do
   node['osl-docker']['service'].each do |key, value|
     send(key.to_sym, value)
   end
-  # Don't try to install docker twice since we do it above
   install_method 'auto'
   action :create
 end

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -32,7 +32,7 @@ describe 'osl-docker::client' do
       it { expect(chef_run.cron('docker_prune_volumes')).to do_nothing }
       it { expect(chef_run.cron('docker_prune_images')).to do_nothing }
       it { expect(chef_run).to stop_docker_service('default') }
-      it { expect(chef_run).to create_docker_installation_package('default') }
+      it { expect(chef_run).to create_docker_service('default') }
 
       case p
       when CENTOS_7

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -44,16 +44,15 @@ describe 'osl-docker::default' do
       it { expect(chef_run).to_not add_osl_shell_environment('DOCKER_TLS_VERIFY') }
       it { expect(chef_run).to_not add_osl_shell_environment('DOCKER_CERT_PATH') }
       it { expect(chef_run).to_not add_osl_shell_environment('DOCKER_HOST') }
-      it { expect(chef_run).to create_docker_installation_package('default') }
+      it { expect(chef_run).to create_docker_service('default') }
 
       it do
-        expect(chef_run).to create_docker_service('default').with(
+        expect(chef_run).to start_docker_service('default').with(
           host: %w(unix:///var/run/docker.sock),
           misc_opts: '--live-restore',
           install_method: 'none'
         )
       end
-      it { expect(chef_run).to start_docker_service('default') }
 
       it do
         expect(chef_run).to create_cron('docker_prune_volumes').with(
@@ -198,7 +197,7 @@ describe 'osl-docker::default' do
         end
 
         it do
-          expect(chef_run).to create_docker_service('default').with(
+          expect(chef_run).to start_docker_service('default').with(
             install_method: 'none',
             tls_verify: true,
             tls_ca_cert: '/etc/docker/ssl/ca.pem',

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -13,8 +13,7 @@ describe 'osl-docker::ibmz_ci' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_docker_service('default')
-        expect(chef_run).to start_docker_service('default').with(
+        expect(chef_run).to create_docker_service('default').with(
           host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2376']
         )
       end

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -13,7 +13,8 @@ describe 'osl-docker::ibmz_ci' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_docker_service('default').with(
+        expect(chef_run).to create_docker_service('default')
+        expect(chef_run).to start_docker_service('default').with(
           host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2376']
         )
       end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -15,7 +15,8 @@ describe 'osl-docker::powerci' do
       end
 
       it do
-        expect(chef_run).to create_docker_service('default').with(
+        expect(chef_run).to create_docker_service('default')
+        expect(chef_run).to start_docker_service('default').with(
           host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']
         )
       end

--- a/spec/unit/recipes/workstation_spec.rb
+++ b/spec/unit/recipes/workstation_spec.rb
@@ -10,7 +10,8 @@ describe 'osl-docker::workstation' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to create_docker_service('default').with(
+        expect(chef_run).to create_docker_service('default')
+        expect(chef_run).to start_docker_service('default').with(
           host: ['unix:///var/run/docker.sock', 'tcp://127.0.0.1:2375']
         )
       end


### PR DESCRIPTION
Looks like there may be an upstream issue with `docker_installation_package`. Replaced with a second `docker_service` command.