### PR TITLE
Remove unused configuration on POWER-CI and IBMZ-CI

### DIFF
--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -16,14 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 node.default['osl-docker']['prune']['volume_filter'] = %w(label!=preserve=true)
-node.default['osl-docker']['tls'] = true
-node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2376'
+node.override['osl-docker']['host'] = 'tcp://0.0.0.0:2375'
 
 include_recipe 'osl-docker::default'
-
-edit_resource!(:osl_firewall_docker, 'osl-docker') do
-  expose_ports true
-end
 
 # docker_volume resource does not have support for labels
 execute 'docker volume create --label preserve=true ccache' do

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -21,13 +21,6 @@ node.default['osl-docker']['prune']['volume_filter'] = %w(label!=preserve=true)
 
 include_recipe 'osl-docker::default'
 
-edit_resource!(:osl_firewall_docker, 'osl-docker') do
-  allowed_ipv4 %w(192.168.6.0/24 140.211.168.207/32)
-  allowed_ipv6 []
-  expose_ports true
-  osl_only false
-end
-
 # docker_volume resource does not have support for labels
 execute 'docker volume create --label preserve=true ccache' do
   not_if 'docker volume inspect ccache'

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -14,7 +14,7 @@ describe 'osl-docker::ibmz_ci' do
       end
       it do
         expect(chef_run).to create_docker_service('default').with(
-          host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2376']
+          host: ['unix:///var/run/docker.sock', 'tcp://0.0.0.0:2375']
         )
       end
       it do

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -33,15 +33,6 @@ describe 'osl-docker::powerci' do
         )
       end
 
-      it do
-        expect(chef_run).to accept_osl_firewall_docker('osl-docker').with(
-          allowed_ipv4: %w(192.168.6.0/24 140.211.168.207/32),
-          allowed_ipv6: [],
-          osl_only: false,
-          expose_ports: true
-        )
-      end
-
       it { expect(chef_run).to run_execute('docker volume create --label preserve=true ccache') }
 
       context 'ccache volume already exists' do

--- a/test/integration/ibmz_ci/inspec/ibmz_ci_spec.rb
+++ b/test/integration/ibmz_ci/inspec/ibmz_ci_spec.rb
@@ -1,10 +1,10 @@
 require_relative '../../helpers/inspec/docker_helper.rb/'
 
-docker_env = 'DOCKER_HOST="tcp://0.0.0.0:2376" DOCKER_CERT_PATH="/etc/docker/ssl" DOCKER_TLS_VERIFY="1"'
+docker_env = 'DOCKER_HOST="tcp://0.0.0.0:2375"'
 
 inspec_docker?(docker_env)
 
-describe port(2376) do
+describe port(2375) do
   it { should be_listening }
 end
 

--- a/test/integration/powerci/inspec/powerci_spec.rb
+++ b/test/integration/powerci/inspec/powerci_spec.rb
@@ -11,21 +11,6 @@ describe crontab do
   its('commands') { should include '/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null' }
 end
 
-describe iptables do
-  ['192.168.6.0/24', '140.211.168.207/32'].each do |ip|
-    it { should have_rule("-A docker -s #{ip} -p tcp -m tcp --dport 2375 -j ACCEPT") }
-    it { should have_rule("-A docker -s #{ip} -p tcp -m tcp --dport 2376 -j ACCEPT") }
-    it { should have_rule("-A docker -s #{ip} -p tcp -m tcp --dport 32768:61000 -j ACCEPT") }
-  end
-end
-
-# make sure firewall isnt allowing IPv6 traffic
-describe ip6tables do
-  it { should_not have_rule('-A docker -p tcp -m tcp --dport 2375 -j ACCEPT') }
-  it { should_not have_rule('-A docker -p tcp -m tcp --dport 2376 -j ACCEPT') }
-  it { should_not have_rule('-A docker -p tcp -m tcp --dport 32768:61000 -j ACCEPT') }
-end
-
 describe command('docker volume inspect ccache') do
   its('exit_status') { should eq 0 }
   its('stdout') { should match(%r{"Mountpoint": "/var/lib/docker/volumes/ccache/_data"}) }


### PR DESCRIPTION
This removes some unused configuration and unifies the configuration between docker nodes on both ppc64le and s390x.

POWER-CI:

- Remove custom firewall settings that aren't needed

IBMZ-CI:

- Remove use of TLS
- Remove custom firewall settings that aren't needed

A lot of this is from the previous interation of how we managed these nodes.

Signed-off-by: Lance Albertson <lance@osuosl.org>
