### PR TITLE
Create osl_dockercompose resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -45,6 +45,14 @@ suites:
       inputs:
         tls: true
         docker_env: 'DOCKER_HOST="tcp://127.0.0.1:2376" DOCKER_CERT_PATH="/etc/docker/ssl" DOCKER_TLS_VERIFY="1"'
+  - name: osl_dockercompose
+    run_list:
+      - recipe[docker_test::compose]
+    verifier:
+      controls:
+        - default
+        - selinux
+        - osl_dockercompose
   - name: client
     run_list:
       - recipe[osl-docker::client]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -35,6 +35,20 @@ module OslDocker
         # only use standard repo on Deb / C7 -- standard repo not available for C8
         platform_family?('debian') || (platform_family?('rhel') && node['platform_version'].to_i == 7)
       end
+
+      def osl_dockercompose_running?
+        cmd = shell_out(
+          'docker compose ls -q',
+          cwd: new_resource.directory
+        )
+
+        if cmd.exitstatus != 0
+          Chef::Log.fatal('Failed executing: docker compose ls -q')
+          Chef::Log.fatal(cmd.stderr)
+        else
+          cmd.stdout.chomp == new_resource.name
+        end
+      end
     end
   end
 end

--- a/resources/dockercompose.rb
+++ b/resources/dockercompose.rb
@@ -1,0 +1,33 @@
+resource_name :osl_dockercompose
+provides :osl_dockercompose
+unified_mode true
+
+default_action :up
+
+property :directory, String, required: true
+property :config, Array, default: []
+
+action :up do
+  execute "#{new_resource.name} up" do
+    command "docker compose -p #{new_resource.name} #{new_resource.config.map { |f| "-f #{f}" }.join(' ')} up -d"
+    cwd new_resource.directory
+    live_stream true
+    not_if { osl_dockercompose_running? }
+  end
+end
+
+action :rebuild do
+  execute "#{new_resource.name} rebuild" do
+    command "docker compose -p #{new_resource.name} #{new_resource.config.map { |f| "-f #{f}" }.join(' ')} up --pull --build -d"
+    cwd new_resource.directory
+    live_stream true
+  end
+end
+
+action :restart do
+  execute "#{new_resource.name} restart" do
+    command "docker compose -p #{new_resource.name} #{new_resource.config.map { |f| "-f #{f}" }.join(' ')} restart"
+    cwd new_resource.directory
+    live_stream true
+  end
+end

--- a/spec/unit/resources/osl_dockercompose_spec.rb
+++ b/spec/unit/resources/osl_dockercompose_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'osl_dockercompose' do
+  platform 'almalinux'
+  step_into :osl_dockercompose
+
+  before do
+    stubs_for_resource('execute[test up]') do |resource|
+      allow(resource).to receive_shell_out('docker compose ls -q', { cwd: '/var/lib/test' })
+    end
+  end
+
+  recipe do
+    osl_dockercompose 'test' do
+      directory '/var/lib/test'
+    end
+
+    osl_dockercompose 'test-configs' do
+      directory '/var/lib/test-configs'
+      config %w(docker-compose.yml docker-compose-common.yml)
+      action [:rebuild, :restart]
+    end
+  end
+
+  it do
+    is_expected.to run_execute('test up').with(
+      command: 'docker compose -p test  up -d',
+      cwd: '/var/lib/test',
+      live_stream: true
+    )
+  end
+
+  it do
+    is_expected.to run_execute('test-configs rebuild').with(
+      command: 'docker compose -p test-configs -f docker-compose.yml -f docker-compose-common.yml up --pull --build -d',
+      cwd: '/var/lib/test-configs',
+      live_stream: true
+    )
+  end
+
+  it do
+    is_expected.to run_execute('test-configs restart').with(
+      command: 'docker compose -p test-configs -f docker-compose.yml -f docker-compose-common.yml restart',
+      cwd: '/var/lib/test-configs',
+      live_stream: true
+    )
+  end
+end

--- a/test/cookbooks/docker_test/files/docker-compose.yml
+++ b/test/cookbooks/docker_test/files/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2.4"
+
+services:
+  hello_world:
+    image: alpine
+    command: [/bin/sleep, '1d']

--- a/test/cookbooks/docker_test/metadata.rb
+++ b/test/cookbooks/docker_test/metadata.rb
@@ -1,2 +1,3 @@
 name 'docker_test'
 version '0.1.0'
+depends 'osl-docker'

--- a/test/cookbooks/docker_test/recipes/compose.rb
+++ b/test/cookbooks/docker_test/recipes/compose.rb
@@ -1,0 +1,12 @@
+include_recipe 'osl-docker'
+
+directory '/var/lib/compose'
+
+cookbook_file '/var/lib/compose/docker-compose.yml' do
+  notifies :rebuild, 'osl_dockercompose[test]'
+  notifies :restart, 'osl_dockercompose[test]'
+end
+
+osl_dockercompose 'test' do
+  directory '/var/lib/compose'
+end

--- a/test/integration/inspec/controls/osl_dockercompose_spec.rb
+++ b/test/integration/inspec/controls/osl_dockercompose_spec.rb
@@ -1,0 +1,8 @@
+control 'osl_dockercompose' do
+  describe docker_container 'test-hello_world-1' do
+    it { should exist }
+    it { should be_running }
+    its('image') { should eq 'alpine' }
+    its('command') { should eq '/bin/sleep 1d' }
+  end
+end


### PR DESCRIPTION
This resource allows someone to minimally control managing docker-compose projects. This is initially needed to deploy and manage Mattermost.

Signed-off-by: Lance Albertson <lance@osuosl.org>
