### PR TITLE
Fix new docker compose CLI syntax

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: client
 #
-# Copyright:: 2019-2023, Oregon State University
+# Copyright:: 2019-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compose.rb
+++ b/recipes/compose.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: compose
 #
-# Copyright:: 2018-2023, Oregon State University
+# Copyright:: 2018-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: default
 #
-# Copyright:: 2017-2023, Oregon State University
+# Copyright:: 2017-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ibmz_ci.rb
+++ b/recipes/ibmz_ci.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: ibmz_ci
 #
-# Copyright:: 2018-2023, Oregon State University
+# Copyright:: 2018-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/nvidia.rb
+++ b/recipes/nvidia.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: nvidia
 #
-# Copyright:: 2019-2023, Oregon State University
+# Copyright:: 2019-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/powerci.rb
+++ b/recipes/powerci.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: powerci
 #
-# Copyright:: 2017-2023, Oregon State University
+# Copyright:: 2017-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/workstation.rb
+++ b/recipes/workstation.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-docker
 # Recipe:: workstation
 #
-# Copyright:: 2017-2023, Oregon State University
+# Copyright:: 2017-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/dockercompose.rb
+++ b/resources/dockercompose.rb
@@ -18,7 +18,7 @@ end
 
 action :rebuild do
   execute "#{new_resource.name} rebuild" do
-    command "docker compose -p #{new_resource.name} #{new_resource.config.map { |f| "-f #{f}" }.join(' ')} up --pull --build -d"
+    command "docker compose -p #{new_resource.name} #{new_resource.config.map { |f| "-f #{f}" }.join(' ')} up --pull always --build -d"
     cwd new_resource.directory
     live_stream true
   end

--- a/spec/unit/resources/osl_dockercompose_spec.rb
+++ b/spec/unit/resources/osl_dockercompose_spec.rb
@@ -32,7 +32,7 @@ describe 'osl_dockercompose' do
 
   it do
     is_expected.to run_execute('test-configs rebuild').with(
-      command: 'docker compose -p test-configs -f docker-compose.yml -f docker-compose-common.yml up --pull --build -d',
+      command: 'docker compose -p test-configs -f docker-compose.yml -f docker-compose-common.yml up --pull always --build -d',
       cwd: '/var/lib/test-configs',
       live_stream: true
     )

--- a/test/integration/inspec/controls/default_spec.rb
+++ b/test/integration/inspec/controls/default_spec.rb
@@ -21,7 +21,7 @@ control 'default' do
 
   %w(docker dockerd).each do |cmd|
     describe command "#{cmd} --version" do
-      its('stdout') { should match(/24.0/) }
+      its('stdout') { should match(/25.0/) }
     end
   end
 


### PR DESCRIPTION
Using --pull now requires a string at the end. For now use always since that's
what we intend on using this for.

Signed-off-by: Lance Albertson <lance@osuosl.org>
