### PR TITLE
Slightly modify Docker's systemd unit to restart when iptables restarts

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -137,3 +137,14 @@ cron 'docker_prune_images' do
   command "/usr/bin/docker system prune -a -f #{volume_filter.join(' ')} > /dev/null"
   not_if { node['osl-docker']['client_only'] }
 end
+
+# In the event the node is utilizing iptables, sync docker to restart when iptables restarts.
+# Docker automatically adds extra rules to iptables, but these changes are not saved on reloads.
+osl_systemd_unit_drop_in 'iptables-fix' do
+  unit_name 'docker.service'
+  content({
+    'Unit' => {
+      'PartOf' => 'iptables.service',
+    },
+  })
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -186,6 +186,17 @@ describe 'osl-docker::default' do
             tls_client_key: '/etc/docker/ssl/key.pem'
           )
         end
+
+        it do
+          expect(chef_run).to create_osl_systemd_unit_drop_in('iptables-fix').with(
+            unit_name: 'docker.service',
+            content: {
+              'Unit' => {
+                'PartOf' => 'iptables.service',
+              },
+            }
+          )
+        end
       end
     end
   end

--- a/test/integration/inspec/controls/default_spec.rb
+++ b/test/integration/inspec/controls/default_spec.rb
@@ -19,9 +19,14 @@ control 'default' do
     end
   end
 
+  describe file '/etc/systemd/system/docker.service.d/iptables-fix.conf' do
+    it { should exist }
+    its('content') { should match 'PartOf = iptables.service' }
+  end
+
   %w(docker dockerd).each do |cmd|
     describe command "#{cmd} --version" do
-      its('stdout') { should match(/25.0/) }
+      its('stdout') { should match(/26.1/) }
     end
   end
 


### PR DESCRIPTION
There has been a prevalent issue when deploying Docker on our current infrastructure, where all network traffic into containers, from sources outside of the VM, are blocked.

The root of the problem stems from **Docker adding new rules to [iptables](https://docs.docker.com/network/packet-filtering-firewalls/) at runtime**, and **iptables not saving these rules in-between restarts**. Due to the way we pre-configure the initial state of iptables, it is impossible to save these changes. There is also a race condition when converging, where we have a delayed action to restart iptables until the end of the converge, meaning any docker containers that are created during the converge will lose their rules.

For this patch, the **Docker service is hooked to restart when iptables is restarted**. This has the massive **consequence of interrupting any current traffic, at the time of a converge**, which modifies iptables. While it is disruptive, it'll at least allow for Docker to continue to function in the event of a restart. Attempts were made to create a pre/post hook on iptables, to save and load the config on restart, but this lead to any iptables rules declared with Chef being completely ignored.

Docker does not have a way to list out its iptables rule changes, which could allow for patching, without restarting the service.