### PR TITLE
Move ghcr_io_credentials library helper from osl-app

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -49,6 +49,18 @@ module OslDocker
           cmd.stdout.chomp == new_resource.name
         end
       end
+
+      def ghcr_io_credentials
+        data_bag_item('docker', 'ghcr-io')
+      rescue Net::HTTPServerException => e
+        if e.response.code == '404'
+          Chef::Log.warn("Could not find databag 'docker:ghcr-io'; falling back to default attributes.")
+          node['docker']['ghcr_io']
+        else
+          Chef::Log.fatal("Unable to load databag 'docker:ghcr-io'; exiting. Please fix the databag and try again.")
+          raise
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Makes more sense to centralize this here in case we use it in other places.

Signed-off-by: Lance Albertson <lance@osuosl.org>
