### PR TITLE
Remove deprecated `version` parameter from docker_compose.yml

### DIFF
--- a/test/cookbooks/docker_test/files/docker-compose.yml
+++ b/test/cookbooks/docker_test/files/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   hello_world:
     image: alpine


### PR DESCRIPTION
Example of the warning message:
```
WARN[0000] /var/lib/mattermost/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```