### PR TITLE
Remove cron cookbook dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,7 @@
+source 'https://supermarket.osuosl.org'
 source 'https://supermarket.chef.io'
 
 solver :ruby, :required
-
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-gpu', git: 'git@github.com:osuosl-cookbooks/osl-gpu', branch: 'main'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
-cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 cookbook 'docker_test', path: 'test/cookbooks/docker_test'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,6 @@ version          '4.14.3'
 
 depends          'apt'
 depends          'certificate'
-depends          'cron'
 depends          'docker', '~> 11.5.0'
 depends          'osl-firewall'
 depends          'osl-gpu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,11 +24,6 @@ osl_firewall_port 'docker_exporter' do
   ports %w(9323)
 end
 
-cron_package 'osl-docker'
-cron_service 'osl-docker' do
-  action [:enable, :start]
-end
-
 node.default['osl-docker']['service']['misc_opts'] = '--live-restore'
 node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
 node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -121,10 +121,6 @@ describe 'osl-docker::default' do
         )
       end
 
-      it { expect(chef_run).to install_cron_package('osl-docker') }
-      it { expect(chef_run).to enable_cron_service('osl-docker') }
-      it { expect(chef_run).to start_cron_service('osl-docker') }
-
       case p
       when *ALL_RHEL
         it do


### PR DESCRIPTION
This is a native resource and no longer needed. Also the cron_package and
cron_service resources are no longer required and have been removed.

Signed-off-by: Lance Albertson <lance@osuosl.org>
