### PR TITLE
Fix transient issues with first chef runs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,3 +41,9 @@ RSpec.configure do |config|
   config.log_level = :warn
   config.file_cache_path = '/var/chef/cache'
 end
+
+shared_context 'common_stubs' do
+  before do
+    stub_command('iptables -C INPUT -j REJECT --reject-with icmp-host-prohibited 2>/dev/null').and_return(true)
+  end
+end

--- a/spec/unit/recipes/client_spec.rb
+++ b/spec/unit/recipes/client_spec.rb
@@ -7,6 +7,8 @@ describe 'osl-docker::client' do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
 
+      include_context 'common_stubs'
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,6 +7,8 @@ describe 'osl-docker::default' do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
 
+      include_context 'common_stubs'
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
@@ -86,6 +88,11 @@ describe 'osl-docker::default' do
               ExecStart=
               ExecStart=#{dockerd_path} -H fd:// --containerd=/run/containerd/containerd.sock --live-restore
             EOC
+          )
+        end
+        it do
+          is_expected.to run_execute('remove_docker_transient_input_reject').with(
+            command: 'iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited'
           )
         end
       end

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -6,9 +6,13 @@ describe 'osl-docker::ibmz_ci' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+
+      include_context 'common_stubs'
+
       before do
         stub_command('docker volume inspect ccache').and_return(false)
       end
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -6,6 +6,9 @@ describe 'osl-docker::nvidia' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+
+      include_context 'common_stubs'
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -6,6 +6,9 @@ describe 'osl-docker::powerci' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p.dup.merge(step_into: %w(osl-docker::default))).converge(described_recipe)
       end
+
+      include_context 'common_stubs'
+
       before do
         stub_command('docker volume inspect ccache').and_return(false)
       end

--- a/spec/unit/recipes/workstation_spec.rb
+++ b/spec/unit/recipes/workstation_spec.rb
@@ -6,6 +6,9 @@ describe 'osl-docker::workstation' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+
+      include_context 'common_stubs'
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end

--- a/test/integration/inspec/controls/default_spec.rb
+++ b/test/integration/inspec/controls/default_spec.rb
@@ -44,6 +44,10 @@ control 'default' do
     end
   end
 
+  describe iptables do
+    it { should_not have_rule('-A INPUT -j REJECT --reject-with icmp-host-prohibited') }
+  end
+
   if client_only
     describe file '/etc/docker/daemon.json' do
       it { should_not exist }


### PR DESCRIPTION
This rule prevents docker apps from accessing anything on the host and gets
fixed on the iptables restart. However that doesn't happen until the end. So
let's remove it by hand here.

Signed-off-by: Lance Albertson <lance@osuosl.org>
