### PR TITLE
Fix issues starting docker on systems using LDAP

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          '4.16.2'
 
 depends          'apt'
 depends          'certificate'
-depends          'docker', '~> 11.5.0'
+depends          'docker', '~> 11.10.0'
 depends          'osl-firewall'
 depends          'osl-gpu'
 depends          'osl-resources'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -156,6 +156,15 @@ osl_systemd_unit_drop_in 'misc-opts' do
   EOC
 end unless osl_docker_setup_repo?
 
+osl_systemd_unit_drop_in 'ldap' do
+  unit_name 'docker.service'
+  content <<~EOC
+    [Unit]
+    After=
+    After=network-online.target docker.socket firewalld.service containerd.service sssd.service
+  EOC
+end
+
 # This rule prevents docker apps from accessing anything on the host and gets fixed on the iptables restart. However
 # that doesn't happen until the end. So let's remove it by hand here.
 rule_to_remove = '-j REJECT --reject-with icmp-host-prohibited'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -91,6 +91,16 @@ describe 'osl-docker::default' do
           )
         end
         it do
+          expect(chef_run).to create_osl_systemd_unit_drop_in('ldap').with(
+            unit_name: 'docker.service',
+            content: <<~EOC
+              [Unit]
+              After=
+              After=network-online.target docker.socket firewalld.service containerd.service sssd.service
+            EOC
+          )
+        end
+        it do
           is_expected.to run_execute('remove_docker_transient_input_reject').with(
             command: 'iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited'
           )


### PR DESCRIPTION
This amends the docker.service to add sssd.service to After so ensure that
service is running before docker tries to start.

Also update to the latest version of the docker cookbook which includes fixes on
Debian platforms.

Signed-off-by: Lance Albertson <lance@osuosl.org>
