### PR TITLE
Use OSL docker repo on ppc64le

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,7 @@ module OslDocker
 
       def osl_docker_setup_repo?
         # have the docker resource setup the docker repos?
-        if %w(riscv64).include? node['kernel']['machine']
+        if %w(riscv64 ppc64le).include? node['kernel']['machine']
           false
         else
           node['osl-docker']['setup_repo']

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,7 @@ depends          'certificate'
 depends          'docker', '~> 11.10.0'
 depends          'osl-firewall'
 depends          'osl-gpu'
+depends          'osl-repos'
 depends          'osl-resources'
 depends          'osl-selinux'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,15 @@ node.default['osl-docker']['service']['misc_opts'] = '--live-restore'
 node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
 node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?
 
+yum_repository 'docker' do
+  baseurl 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch'
+  gpgkey osl_gpg_key
+  description 'Docker Stable repository'
+  gpgcheck true
+  enabled true
+  only_if { %w(ppc64le).include?(node['kernel']['machine']) && rhel? }
+end
+
 docker_service 'default' do
   node['osl-docker']['service'].each do |key, value|
     send(key.to_sym, value)


### PR DESCRIPTION
Upstream no longer supports binaries on ppc64le so we need to build them
ourselves.

Signed-off-by: Lance Albertson <lance@osuosl.org>
