### PR TITLE
Fix logic around package name

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,10 +2,10 @@ module OslDocker
   module Cookbook
     module Helpers
       def osl_docker_package_name
-        if osl_docker_setup_repo?
-          'docker-ce'
-        else
+        if !osl_docker_setup_repo? && debian?
           'docker.io'
+        else
+          'docker-ce'
         end
       end
 


### PR DESCRIPTION
It was assumed if we weren't using the upstream repo, then this must be a debian
based system so use the distro package name instead.

However now that we're also doing this with ppc64le on RHEL, we need to update
the logic since this is using the upstream package name still.

Signed-off-by: Lance Albertson <lance@osuosl.org>
