### PR TITLE
Set explicit DNS and scope down hourly prune

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,7 @@ default['osl-docker']['daemon'] =
     'metrics-addr' => '0.0.0.0:9323',
     'experimental' => true,
     'ip6tables' => true,
+    'dns' => %w(140.211.166.130 140.211.166.131 216.165.191.54),
     'log-opts' => {
       'max-size' => '100m',
       'max-file' => '10',

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -133,7 +133,13 @@ end
 
 cron 'docker_prune_volumes' do
   minute '15'
-  command "/usr/bin/docker system prune --volumes -f #{volume_filter.join(' ')} > /dev/null"
+  command "/usr/bin/docker volume prune -f #{volume_filter.join(' ')} > /dev/null"
+  not_if { node['osl-docker']['client_only'] }
+end
+
+cron 'docker_prune_containers' do
+  minute '20'
+  command '/usr/bin/docker container prune -f --filter until=4h > /dev/null'
   not_if { node['osl-docker']['client_only'] }
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -32,6 +32,7 @@ describe 'osl-docker::default' do
               'metrics-addr' => '0.0.0.0:9323',
               'experimental' => true,
               'ip6tables' => true,
+              'dns' => %w(140.211.166.130 140.211.166.131 216.165.191.54),
               'log-opts' => {
                 'max-size' => '100m',
                 'max-file' => '10',
@@ -169,25 +170,15 @@ describe 'osl-docker::default' do
       it do
         expect(chef_run).to create_cron('docker_prune_volumes').with(
           minute: '15',
-          command: '/usr/bin/docker system prune --volumes -f  > /dev/null'
+          command: '/usr/bin/docker volume prune -f  > /dev/null'
         )
       end
       it do
-        expect(chef_run).to create_cron('docker_prune_images').with(
-          minute: '45',
-          hour: '2',
-          weekday: '0',
-          command: '/usr/bin/docker system prune -a -f  > /dev/null'
+        expect(chef_run).to create_cron('docker_prune_containers').with(
+          minute: '20',
+          command: '/usr/bin/docker container prune -f --filter until=4h > /dev/null'
         )
       end
-
-      it do
-        expect(chef_run).to create_cron('docker_prune_volumes').with(
-          minute: '15',
-          command: '/usr/bin/docker system prune --volumes -f  > /dev/null'
-        )
-      end
-
       it do
         expect(chef_run).to create_cron('docker_prune_images').with(
           minute: '45',

--- a/spec/unit/recipes/ibmz_ci_spec.rb
+++ b/spec/unit/recipes/ibmz_ci_spec.rb
@@ -24,7 +24,13 @@ describe 'osl-docker::ibmz_ci' do
       it do
         expect(chef_run).to create_cron('docker_prune_volumes')
           .with(
-            command: '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null'
+            command: '/usr/bin/docker volume prune -f --filter label!=preserve=true > /dev/null'
+          )
+      end
+      it do
+        expect(chef_run).to create_cron('docker_prune_containers')
+          .with(
+            command: '/usr/bin/docker container prune -f --filter until=4h > /dev/null'
           )
       end
       it do

--- a/spec/unit/recipes/nvidia_spec.rb
+++ b/spec/unit/recipes/nvidia_spec.rb
@@ -30,6 +30,7 @@ describe 'osl-docker::nvidia' do
                 'metrics-addr' => '0.0.0.0:9323',
                 'experimental' => true,
                 'ip6tables' => true,
+                'dns' => %w(140.211.166.130 140.211.166.131 216.165.191.54),
                 'log-opts' => {
                   'max-size' => '100m',
                   'max-file' => '10',

--- a/spec/unit/recipes/powerci_spec.rb
+++ b/spec/unit/recipes/powerci_spec.rb
@@ -26,7 +26,13 @@ describe 'osl-docker::powerci' do
 
       it do
         expect(chef_run).to create_cron('docker_prune_volumes').with(
-          command: '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null'
+          command: '/usr/bin/docker volume prune -f --filter label!=preserve=true > /dev/null'
+        )
+      end
+
+      it do
+        expect(chef_run).to create_cron('docker_prune_containers').with(
+          command: '/usr/bin/docker container prune -f --filter until=4h > /dev/null'
         )
       end
 

--- a/test/integration/inspec/controls/default_spec.rb
+++ b/test/integration/inspec/controls/default_spec.rb
@@ -59,7 +59,8 @@ control 'default' do
     end
 
     describe crontab do
-      its('commands') { should_not include '/usr/bin/docker system prune --volumes -f  > /dev/null' }
+      its('commands') { should_not include '/usr/bin/docker volume prune -f  > /dev/null' }
+      its('commands') { should_not include '/usr/bin/docker container prune -f --filter until=4h > /dev/null' }
       its('commands') { should_not include '/usr/bin/docker system prune -a -f  > /dev/null' }
     end
   else
@@ -71,13 +72,21 @@ control 'default' do
     describe json '/etc/docker/daemon.json' do
       its('metrics-addr') { should cmp '0.0.0.0:9323' }
       its('experimental') { should cmp 'true' }
+      its('dns') { should cmp %w(140.211.166.130 140.211.166.131 216.165.191.54) }
       its('registry-mirrors') { should cmp %w(https://registry.osuosl.org) }
       its(%w(log-opts max-size)) { should cmp '100m' }
       its(%w(log-opts max-file)) { should cmp '10' }
     end
 
-    describe crontab.where { command =~ /docker system prune --volumes/ } do
+    describe crontab.where { command =~ /docker volume prune/ } do
       its('minutes') { should cmp '15' }
+      its('hours') { should cmp '*' }
+      its('days') { should cmp '*' }
+      its('months') { should cmp '*' }
+    end
+
+    describe crontab.where { command =~ /docker container prune/ } do
+      its('minutes') { should cmp '20' }
       its('hours') { should cmp '*' }
       its('days') { should cmp '*' }
       its('months') { should cmp '*' }

--- a/test/integration/inspec/controls/ibmz_ci_spec.rb
+++ b/test/integration/inspec/controls/ibmz_ci_spec.rb
@@ -4,7 +4,8 @@ control 'ibmz-ci' do
   end
 
   describe crontab do
-    its('commands') { should include '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null' }
+    its('commands') { should include '/usr/bin/docker volume prune -f --filter label!=preserve=true > /dev/null' }
+    its('commands') { should include '/usr/bin/docker container prune -f --filter until=4h > /dev/null' }
     its('commands') { should include '/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null' }
   end
 

--- a/test/integration/inspec/controls/powerci_spec.rb
+++ b/test/integration/inspec/controls/powerci_spec.rb
@@ -4,7 +4,8 @@ control 'powerci' do
   end
 
   describe crontab do
-    its('commands') { should include '/usr/bin/docker system prune --volumes -f --filter label!=preserve=true > /dev/null' }
+    its('commands') { should include '/usr/bin/docker volume prune -f --filter label!=preserve=true > /dev/null' }
+    its('commands') { should include '/usr/bin/docker container prune -f --filter until=4h > /dev/null' }
     its('commands') { should include '/usr/bin/docker system prune -a -f --filter label!=preserve=true > /dev/null' }
   end
 


### PR DESCRIPTION
Containers running on docker-executor gitlab-runners were intermittently
failing with "Could not resolve host" because dockerd was falling back to
8.8.8.8 (host /etc/resolv.conf points at systemd-resolved on 127.0.0.53,
which dockerd cannot pass into a container netns).

Set 'dns' in the daemon defaults so every container's /etc/resolv.conf
points at OSL's resolvers directly.

Also split the hourly 'docker system prune --volumes -f' into a
'docker volume prune' plus a scoped 'docker container prune --filter
until=4h'. The old form pruned unused networks too, which could yank a
runner's bridge between jobs.

Signed-off-by: Lance Albertson <lance@osuosl.org>
