### PR TITLE
Order docker after iptables/ip6tables to prevent bridge half-restore

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -151,13 +151,15 @@ cron 'docker_prune_images' do
   not_if { node['osl-docker']['client_only'] }
 end
 
-# In the event the node is utilizing iptables, sync docker to restart when iptables restarts.
+# In the event the node is utilizing iptables, sync docker to restart when iptables or ip6tables restarts.
 # Docker automatically adds extra rules to iptables, but these changes are not saved on reloads.
+# The matching After= ordering lives in the 'ldap' drop-in below: drop-ins parse in lexical order and ldap.conf
+# resets After=, so anything added here would be discarded.
 osl_systemd_unit_drop_in 'iptables-fix' do
   unit_name 'docker.service'
   content({
             'Unit' => {
-              'PartOf' => 'iptables.service',
+              'PartOf' => 'iptables.service ip6tables.service',
             },
           })
 end
@@ -178,12 +180,16 @@ else
   end
 end
 
+# dockerd must never start while iptables/ip6tables are mid-restore: with --live-restore and containers running, a
+# failed bridge-network restore at startup leaves the default bridge half-restored and every new container fails with
+# "network <id> does not exist" until the next docker restart (same defect class as moby/moby#52642).
 osl_systemd_unit_drop_in 'ldap' do
   unit_name 'docker.service'
   content <<~EOC
     [Unit]
     After=
     After=network-online.target docker.socket firewalld.service containerd.service sssd.service
+    After=iptables.service ip6tables.service
   EOC
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -101,6 +101,7 @@ describe 'osl-docker::default' do
                 [Unit]
                 After=
                 After=network-online.target docker.socket firewalld.service containerd.service sssd.service
+                After=iptables.service ip6tables.service
               EOC
             )
           end
@@ -293,7 +294,7 @@ describe 'osl-docker::default' do
             unit_name: 'docker.service',
             content: {
               'Unit' => {
-                'PartOf' => 'iptables.service',
+                'PartOf' => 'iptables.service ip6tables.service',
               },
             }
           )

--- a/test/integration/inspec/controls/default_spec.rb
+++ b/test/integration/inspec/controls/default_spec.rb
@@ -20,9 +20,14 @@ control 'default' do
 
   describe command 'systemctl show docker.service' do
     if debian
-      its('stdout') { should match /^PartOf=netfilter-persistent.service$/ }
+      # iptables.service is an alias of netfilter-persistent.service on debian
+      its('stdout') { should match /^PartOf=.*netfilter-persistent.service/ }
+      its('stdout') { should match /^After=.*netfilter-persistent.service/ }
     else
-      its('stdout') { should match /^PartOf=iptables.service$/ }
+      its('stdout') { should match /^PartOf=.*iptables.service/ }
+      its('stdout') { should match /^PartOf=.*ip6tables.service/ }
+      its('stdout') { should match /^After=.*iptables.service/ }
+      its('stdout') { should match /^After=.*ip6tables.service/ }
     end
     its('stdout') { should match /^After=.*sssd.service/ }
   end


### PR DESCRIPTION
If dockerd starts while iptables is mid-restore (via the PartOf=
coupled restart), the bridge network restore can fail under
--live-restore, leaving the default bridge half-restored: every new
container fails with "network <id> does not exist" until the next
docker restart (same defect class as moby/moby#52642). Seen on our
GitLab CI runners as recurring "Preparation failed: adding cache
volume" system failures.

- Add After=iptables.service ip6tables.service so propagated docker
  restarts only start dockerd once the firewall restore has finished
- Place the ordering in the ldap drop-in: ldap.conf resets After= and
  parses after iptables-fix.conf, which would discard it
- Extend PartOf= to ip6tables.service: docker programs ip6tables rules
  too, and an ip6tables-only restart flushed them without restarting
  docker
- Both entries are inert on Debian (iptables.service aliases
  netfilter-persistent; ip6tables.service does not exist)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
