### PR TITLE
osl_dockercompose: Require every defined service to be running

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,11 +27,10 @@ module OslDocker
       end
 
       def osl_dockercompose_running?
+        compose_cmd = "docker compose -p #{new_resource.name} #{new_resource.config_files.map { |f| "-f #{f}" }.join(' ')}"
+
         # Check if all containers in the compose project are running
-        cmd = shell_out(
-          "docker compose -p #{new_resource.name} #{new_resource.config_files.map { |f| "-f #{f}" }.join(' ')} ps -a --format json",
-          cwd: new_resource.directory
-        )
+        cmd = shell_out("#{compose_cmd} ps -a --format json", cwd: new_resource.directory)
 
         if cmd.exitstatus != 0
           # If the command fails, the project likely doesn't exist yet
@@ -47,8 +46,32 @@ module OslDocker
         # If no containers are defined or found, consider it as not running
         return false if containers.empty?
 
-        # Check if all containers have State == "running"
-        containers.all? { |container| container['State'] == 'running' }
+        # `ps` cannot report a container that no longer exists, so a service whose
+        # container was removed outright looks identical to a project that never
+        # defined it. That is not hypothetical: the docker_prune_containers cron
+        # reaps any container that has been stopped for 4h, so a service that
+        # crashes overnight silently disappears here. Ask the compose file what is
+        # supposed to be running instead of trusting what happens to be left.
+        services = shell_out("#{compose_cmd} config --services", cwd: new_resource.directory)
+
+        if services.exitstatus != 0
+          Chef::Log.debug("docker compose config failed for #{new_resource.name}, assuming not running")
+          return false
+        end
+
+        defined_services = services.stdout.split(/\r?\n/).map(&:strip).reject(&:empty?)
+        return false if defined_services.empty?
+
+        # Group by service so that a scaled service still counts as down when only
+        # some of its replicas are up. Containers belonging to a service the file
+        # no longer defines are ignored: `up` does not reap orphans, so failing on
+        # them would re-run the compose command on every converge forever.
+        containers_by_service = containers.group_by { |container| container['Service'] }
+
+        defined_services.all? do |service|
+          instances = containers_by_service[service].to_a
+          instances.any? && instances.all? { |container| container['State'] == 'running' }
+        end
       end
 
       def osl_dockerd_path

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -30,17 +30,23 @@ RSpec.describe OslDocker::Cookbook::Helpers do
 
   describe '#osl_dockercompose_running?' do
     let(:shell_out_result) { double('shell_out_result', exitstatus: exitstatus, stdout: stdout) }
+    let(:config_exitstatus) { 0 }
+    let(:config_services) { %w(web db) }
+    let(:config_result) do
+      double('config_result', exitstatus: config_exitstatus, stdout: "#{config_services.join("\n")}\n")
+    end
 
     before do
-      allow(subject).to receive(:shell_out).and_return(shell_out_result)
+      allow(subject).to receive(:shell_out).with(/ps -a --format json/, any_args).and_return(shell_out_result)
+      allow(subject).to receive(:shell_out).with(/config --services/, any_args).and_return(config_result)
     end
 
     context 'when all containers are running' do
       let(:exitstatus) { 0 }
       let(:stdout) do
         <<~JSON
-          {"Name":"test-compose-web-1","State":"running","Status":"Up 5 minutes"}
-          {"Name":"test-compose-db-1","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-db-1","Service":"db","State":"running","Status":"Up 5 minutes"}
         JSON
       end
 
@@ -55,14 +61,22 @@ RSpec.describe OslDocker::Cookbook::Helpers do
           cwd: '/var/lib/compose'
         )
       end
+
+      it 'calls docker compose config with correct arguments' do
+        subject.osl_dockercompose_running?
+        expect(subject).to have_received(:shell_out).with(
+          'docker compose -p test-compose -f docker-compose.yml config --services',
+          cwd: '/var/lib/compose'
+        )
+      end
     end
 
     context 'when some containers are stopped' do
       let(:exitstatus) { 0 }
       let(:stdout) do
         <<~JSON
-          {"Name":"test-compose-web-1","State":"running","Status":"Up 5 minutes"}
-          {"Name":"test-compose-db-1","State":"exited","Status":"Exited (1) 2 minutes ago"}
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-db-1","Service":"db","State":"exited","Status":"Exited (1) 2 minutes ago"}
         JSON
       end
 
@@ -75,8 +89,90 @@ RSpec.describe OslDocker::Cookbook::Helpers do
       let(:exitstatus) { 0 }
       let(:stdout) do
         <<~JSON
-          {"Name":"test-compose-web-1","State":"exited","Status":"Exited (0) 10 minutes ago"}
-          {"Name":"test-compose-db-1","State":"exited","Status":"Exited (1) 10 minutes ago"}
+          {"Name":"test-compose-web-1","Service":"web","State":"exited","Status":"Exited (0) 10 minutes ago"}
+          {"Name":"test-compose-db-1","Service":"db","State":"exited","Status":"Exited (1) 10 minutes ago"}
+        JSON
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+    end
+
+    context 'when a defined service has no container at all' do
+      let(:exitstatus) { 0 }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+        JSON
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+    end
+
+    context 'when a scaled service has a stopped replica' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web) }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-web-2","Service":"web","State":"exited","Status":"Exited (1) 2 minutes ago"}
+        JSON
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+    end
+
+    context 'when a stopped container belongs to a service no longer defined' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web) }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-orphan-1","Service":"orphan","State":"exited","Status":"Exited (0) 2 minutes ago"}
+        JSON
+      end
+
+      it 'ignores the orphan and returns true' do
+        expect(subject.osl_dockercompose_running?).to eq true
+      end
+    end
+
+    context 'when docker compose config command fails' do
+      let(:exitstatus) { 0 }
+      let(:config_exitstatus) { 1 }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+        JSON
+      end
+
+      before do
+        allow(Chef::Log).to receive(:debug)
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+
+      it 'logs a debug message' do
+        subject.osl_dockercompose_running?
+        expect(Chef::Log).to have_received(:debug).with(
+          'docker compose config failed for test-compose, assuming not running'
+        )
+      end
+    end
+
+    context 'when the compose file defines no services' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { [] }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
         JSON
       end
 
@@ -124,9 +220,10 @@ RSpec.describe OslDocker::Cookbook::Helpers do
         )
       end
       let(:exitstatus) { 0 }
+      let(:config_services) { %w(service) }
       let(:stdout) do
         <<~JSON
-          {"Name":"multi-config-service-1","State":"running","Status":"Up 1 hour"}
+          {"Name":"multi-config-service-1","Service":"service","State":"running","Status":"Up 1 hour"}
         JSON
       end
 
@@ -134,6 +231,14 @@ RSpec.describe OslDocker::Cookbook::Helpers do
         subject.osl_dockercompose_running?
         expect(subject).to have_received(:shell_out).with(
           'docker compose -p multi-config -f docker-compose.yml -f docker-compose.override.yml ps -a --format json',
+          cwd: '/opt/services'
+        )
+      end
+
+      it 'includes all config files in the config command' do
+        subject.osl_dockercompose_running?
+        expect(subject).to have_received(:shell_out).with(
+          'docker compose -p multi-config -f docker-compose.yml -f docker-compose.override.yml config --services',
           cwd: '/opt/services'
         )
       end
@@ -149,9 +254,10 @@ RSpec.describe OslDocker::Cookbook::Helpers do
         )
       end
       let(:exitstatus) { 0 }
+      let(:config_services) { %w(app) }
       let(:stdout) do
         <<~JSON
-          {"Name":"no-configs-app-1","State":"running","Status":"Up 30 seconds"}
+          {"Name":"no-configs-app-1","Service":"app","State":"running","Status":"Up 30 seconds"}
         JSON
       end
 
@@ -166,6 +272,7 @@ RSpec.describe OslDocker::Cookbook::Helpers do
 
     context 'when container has different states' do
       let(:exitstatus) { 0 }
+      let(:config_services) { %w(web) }
 
       [
         { state: 'restarting', expected: false },
@@ -177,7 +284,7 @@ RSpec.describe OslDocker::Cookbook::Helpers do
         context "when state is #{test_case[:state]}" do
           let(:stdout) do
             <<~JSON
-              {"Name":"test-compose-web-1","State":"#{test_case[:state]}","Status":"..."}
+              {"Name":"test-compose-web-1","Service":"web","State":"#{test_case[:state]}","Status":"..."}
             JSON
           end
 
@@ -190,7 +297,11 @@ RSpec.describe OslDocker::Cookbook::Helpers do
 
     context 'with mixed line endings' do
       let(:exitstatus) { 0 }
-      let(:stdout) { "{\"Name\":\"test-1\",\"State\":\"running\"}\r\n{\"Name\":\"test-2\",\"State\":\"running\"}\n" }
+      let(:config_services) { %w(one two) }
+      let(:stdout) do
+        "{\"Name\":\"test-1\",\"Service\":\"one\",\"State\":\"running\"}\r\n" \
+          "{\"Name\":\"test-2\",\"Service\":\"two\",\"State\":\"running\"}\n"
+      end
 
       it 'handles both CRLF and LF line endings' do
         expect(subject.osl_dockercompose_running?).to eq true
@@ -199,11 +310,12 @@ RSpec.describe OslDocker::Cookbook::Helpers do
 
     context 'with empty lines in output' do
       let(:exitstatus) { 0 }
+      let(:config_services) { %w(one two) }
       let(:stdout) do
         <<~JSON
-          {"Name":"test-1","State":"running"}
+          {"Name":"test-1","Service":"one","State":"running"}
 
-          {"Name":"test-2","State":"running"}
+          {"Name":"test-2","Service":"two","State":"running"}
         JSON
       end
 

--- a/spec/unit/resources/osl_dockercompose_spec.rb
+++ b/spec/unit/resources/osl_dockercompose_spec.rb
@@ -6,11 +6,19 @@ describe 'osl_dockercompose' do
 
   before do
     stubs_for_resource('execute[test up]') do |resource|
-      # Stub for docker compose ps -a --format json (returns empty, so not running)
+      # web is up, but db has no container at all, so the project is not running
+      # and the execute has to run.
       allow(resource).to receive_shell_out(
         'docker compose -p test  ps -a --format json',
         { cwd: '/var/lib/test' }
-      ).and_return(double(exitstatus: 0, stdout: ''))
+      ).and_return(
+        double(exitstatus: 0, stdout: %({"Name":"test-web-1","Service":"web","State":"running"}\n))
+      )
+
+      allow(resource).to receive_shell_out(
+        'docker compose -p test  config --services',
+        { cwd: '/var/lib/test' }
+      ).and_return(double(exitstatus: 0, stdout: "web\ndb\n"))
     end
   end
 


### PR DESCRIPTION
osl_dockercompose_running? only inspected the containers `docker compose ps`
returned, so a service whose container had been removed outright looked
identical to one that was never defined. The survivors all report running,
the guard returns true, `up` is skipped, and the dead service is never
brought back while Chef reports a clean converge every time.

This is not hypothetical: osl-docker's own docker_prune_containers cron runs
`docker container prune -f --filter until=4h` hourly, so any service that
crashes and stays down long enough has its container reaped and then goes
unnoticed. It cost us invasives-production-app-1 in the app3 suite, where the
container had vanished entirely, the converge still passed, and only inspec
caught it.

Ask `docker compose config --services` what should be running rather than
trusting what is left, and require each service to have a running container.
Containers are grouped by service, so a service counts as down when any of
its containers is stopped. This checks presence, not replica count: a scaled
service that loses a replica to the pruner still reports as running, exactly
as it did before. Orphans from a service that is no longer defined are
ignored: `up` does not reap them, so failing on them would re-run the compose
command on every converge and break idempotency the other way.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
