### PR TITLE
Use the upstream rhel repo for docker on s390x

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,7 +10,8 @@ module OslDocker
       end
 
       def osl_docker_service_manager
-        if osl_docker_setup_repo?
+        # s390x only needs its repo managed by us; the service stays cookbook-managed
+        if osl_docker_setup_repo? || osl_docker_s390x_rhel?
           'auto'
         else
           'none'
@@ -19,10 +20,33 @@ module OslDocker
 
       def osl_docker_setup_repo?
         # have the docker resource setup the docker repos?
-        if %w(riscv64 ppc64le).include? node['kernel']['machine']
+        if %w(riscv64 ppc64le).include?(node['kernel']['machine']) || osl_docker_s390x_rhel?
           false
         else
           node['osl-docker']['setup_repo']
+        end
+      end
+
+      # The docker cookbook maps AlmaLinux to the upstream "centos" repo, which
+      # carries no s390x packages; only the "rhel" repo does. Manage the repo
+      # ourselves on those nodes until this is fixed upstream.
+      def osl_docker_s390x_rhel?
+        node['kernel']['machine'] == 's390x' && rhel?
+      end
+
+      def osl_docker_repo_baseurl
+        if osl_docker_s390x_rhel?
+          'https://download.docker.com/linux/rhel/$releasever/$basearch/stable'
+        else
+          'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch'
+        end
+      end
+
+      def osl_docker_repo_gpgkey
+        if osl_docker_s390x_rhel?
+          'https://download.docker.com/linux/rhel/gpg'
+        else
+          osl_gpg_key
         end
       end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,12 +29,19 @@ node.default['osl-docker']['service']['host'] = ['unix:///var/run/docker.sock']
 node.default['osl-docker']['service']['host'] << node['osl-docker']['host'] unless node['osl-docker']['host'].nil?
 
 yum_repository 'docker' do
-  baseurl 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch'
-  gpgkey osl_gpg_key
+  baseurl osl_docker_repo_baseurl
+  gpgkey osl_docker_repo_gpgkey
   description 'Docker Stable repository'
   gpgcheck true
   enabled true
-  only_if { %w(ppc64le).include?(node['kernel']['machine']) && rhel? }
+  only_if { %w(ppc64le s390x).include?(node['kernel']['machine']) && rhel? }
+end
+
+# The docker cookbook removes these alongside its repo setup since they conflict
+# with docker-ce's dependencies; keep doing that where we manage the repo instead
+package %w(buildah podman) do
+  action :remove
+  only_if { osl_docker_s390x_rhel? }
 end
 
 docker_service 'default' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -168,6 +168,50 @@ describe 'osl-docker::default' do
         end
       end
 
+      context 's390x' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.automatic['kernel']['machine'] = 's390x'
+          end.converge(described_recipe)
+        end
+
+        case p
+        when *ALL_RHEL
+          it do
+            expect(chef_run).to create_docker_service('default').with(
+              setup_docker_repo: false,
+              package_name: 'docker-ce',
+              service_manager: 'auto',
+              host: %w(unix:///var/run/docker.sock),
+              misc_opts: '--live-restore'
+            )
+          end
+
+          it do
+            is_expected.to create_yum_repository('docker').with(
+              baseurl: 'https://download.docker.com/linux/rhel/$releasever/$basearch/stable',
+              gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+              description: 'Docker Stable repository',
+              gpgcheck: true,
+              enabled: true
+            )
+          end
+
+          it { is_expected.to remove_package 'buildah, podman' }
+        else
+          it { is_expected.to_not create_yum_repository 'docker' }
+          it { is_expected.to_not remove_package 'buildah, podman' }
+
+          it do
+            expect(chef_run).to create_docker_service('default').with(
+              setup_docker_repo: true,
+              package_name: 'docker-ce',
+              service_manager: 'auto'
+            )
+          end
+        end
+      end
+
       it do
         expect(chef_run).to create_cron('docker_prune_volumes').with(
           minute: '15',


### PR DESCRIPTION
Our s390x nodes moved from RHEL to AlmaLinux, which the docker cookbook
maps to the upstream "centos" repo. That repo carries no s390x packages;
only the "rhel" repo does.

- Manage the yum repo ourselves on s390x rhel nodes, pointing at the
  upstream rhel baseurl and gpg key
- Keep the service manager on 'auto' since only the repo handling needs
  to be overridden
- Remove buildah/podman on s390x, matching what the docker cookbook does
  when it manages the repo itself

This can be reverted once the upstream docker cookbook handles s390x on
AlmaLinux correctly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
