### PR TITLE
osl_dockercompose: Ignore one-shot services in running check

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -76,14 +76,18 @@ module OslDocker
         # reaps any container that has been stopped for 4h, so a service that
         # crashes overnight silently disappears here. Ask the compose file what is
         # supposed to be running instead of trusting what happens to be left.
-        services = shell_out("#{compose_cmd} config --services", cwd: new_resource.directory)
+        config = shell_out("#{compose_cmd} config --format json", cwd: new_resource.directory)
 
-        if services.exitstatus != 0
+        if config.exitstatus != 0
           Chef::Log.debug("docker compose config failed for #{new_resource.name}, assuming not running")
           return false
         end
 
-        defined_services = services.stdout.split(/\r?\n/).map(&:strip).reject(&:empty?)
+        # One-shot services (restart "no", e.g. a migration gate) are expected to
+        # exit, and their stopped containers get pruned; `up --wait` already
+        # enforces their success through depends_on conditions. Only services
+        # meant to stay up count toward the running check.
+        defined_services = JSON.parse(config.stdout)['services'].to_h.reject { |_, svc| svc['restart'] == 'no' }.keys
         return false if defined_services.empty?
 
         # Group by service so that a scaled service still counts as down when only

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe OslDocker::Cookbook::Helpers do
     let(:shell_out_result) { double('shell_out_result', exitstatus: exitstatus, stdout: stdout) }
     let(:config_exitstatus) { 0 }
     let(:config_services) { %w(web db) }
+    let(:config_restarts) { {} }
     let(:config_result) do
-      double('config_result', exitstatus: config_exitstatus, stdout: "#{config_services.join("\n")}\n")
+      services = config_services.to_h { |s| [s, config_restarts.key?(s) ? { 'restart' => config_restarts[s] } : {}] }
+      double('config_result', exitstatus: config_exitstatus, stdout: JSON.generate('services' => services))
     end
 
     before do
       allow(subject).to receive(:shell_out).with(/ps -a --format json/, any_args).and_return(shell_out_result)
-      allow(subject).to receive(:shell_out).with(/config --services/, any_args).and_return(config_result)
+      allow(subject).to receive(:shell_out).with(/config --format json/, any_args).and_return(config_result)
     end
 
     context 'when all containers are running' do
@@ -65,7 +67,7 @@ RSpec.describe OslDocker::Cookbook::Helpers do
       it 'calls docker compose config with correct arguments' do
         subject.osl_dockercompose_running?
         expect(subject).to have_received(:shell_out).with(
-          'docker compose -p test-compose -f docker-compose.yml config --services',
+          'docker compose -p test-compose -f docker-compose.yml config --format json',
           cwd: '/var/lib/compose'
         )
       end
@@ -139,6 +141,83 @@ RSpec.describe OslDocker::Cookbook::Helpers do
 
       it 'ignores the orphan and returns true' do
         expect(subject.osl_dockercompose_running?).to eq true
+      end
+    end
+
+    context 'when a one-shot service has exited successfully' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web migrate) }
+      let(:config_restarts) { { 'migrate' => 'no' } }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+          {"Name":"test-compose-migrate-1","Service":"migrate","State":"exited","Status":"Exited (0) 5 minutes ago"}
+        JSON
+      end
+
+      it 'ignores the one-shot and returns true' do
+        expect(subject.osl_dockercompose_running?).to eq true
+      end
+    end
+
+    context 'when a one-shot service container was pruned' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web migrate) }
+      let(:config_restarts) { { 'migrate' => 'no' } }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"running","Status":"Up 5 minutes"}
+        JSON
+      end
+
+      it 'ignores the missing one-shot and returns true' do
+        expect(subject.osl_dockercompose_running?).to eq true
+      end
+    end
+
+    context 'when a long-running service is stopped alongside a one-shot' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web migrate) }
+      let(:config_restarts) { { 'migrate' => 'no' } }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"exited","Status":"Exited (1) 2 minutes ago"}
+          {"Name":"test-compose-migrate-1","Service":"migrate","State":"exited","Status":"Exited (0) 5 minutes ago"}
+        JSON
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+    end
+
+    context 'when a stopped service has a non-no restart policy' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(web) }
+      let(:config_restarts) { { 'web' => 'unless-stopped' } }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-web-1","Service":"web","State":"exited","Status":"Exited (1) 2 minutes ago"}
+        JSON
+      end
+
+      it 'still counts the service and returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
+      end
+    end
+
+    context 'when every service is a one-shot' do
+      let(:exitstatus) { 0 }
+      let(:config_services) { %w(migrate) }
+      let(:config_restarts) { { 'migrate' => 'no' } }
+      let(:stdout) do
+        <<~JSON
+          {"Name":"test-compose-migrate-1","Service":"migrate","State":"exited","Status":"Exited (0) 5 minutes ago"}
+        JSON
+      end
+
+      it 'returns false' do
+        expect(subject.osl_dockercompose_running?).to eq false
       end
     end
 
@@ -238,7 +317,7 @@ RSpec.describe OslDocker::Cookbook::Helpers do
       it 'includes all config files in the config command' do
         subject.osl_dockercompose_running?
         expect(subject).to have_received(:shell_out).with(
-          'docker compose -p multi-config -f docker-compose.yml -f docker-compose.override.yml config --services',
+          'docker compose -p multi-config -f docker-compose.yml -f docker-compose.override.yml config --format json',
           cwd: '/opt/services'
         )
       end

--- a/spec/unit/resources/osl_dockercompose_spec.rb
+++ b/spec/unit/resources/osl_dockercompose_spec.rb
@@ -16,9 +16,9 @@ describe 'osl_dockercompose' do
       )
 
       allow(resource).to receive_shell_out(
-        'docker compose -p test  config --services',
+        'docker compose -p test  config --format json',
         { cwd: '/var/lib/test' }
-      ).and_return(double(exitstatus: 0, stdout: "web\ndb\n"))
+      ).and_return(double(exitstatus: 0, stdout: %({"services":{"web":{},"db":{}}})))
     end
   end
 

--- a/test/cookbooks/docker_test/files/docker-oneshot.yml
+++ b/test/cookbooks/docker_test/files/docker-oneshot.yml
@@ -1,0 +1,11 @@
+services:
+  migrate:
+    image: alpine
+    command: [/bin/echo, migrated]
+    restart: "no"
+  hello_world:
+    image: alpine
+    command: [/bin/sleep, '1d']
+    depends_on:
+      migrate:
+        condition: service_completed_successfully

--- a/test/cookbooks/docker_test/recipes/compose.rb
+++ b/test/cookbooks/docker_test/recipes/compose.rb
@@ -14,6 +14,10 @@ cookbook_file '/var/lib/compose/docker-service2.yml' do
   notifies :rebuild, 'osl_dockercompose[services]'
 end
 
+# No rebuild notification: the delayed rebuild would recreate the exited
+# one-shot container after the prune below, breaking the prune simulation.
+cookbook_file '/var/lib/compose/docker-oneshot.yml'
+
 osl_dockercompose 'test' do
   directory '/var/lib/compose'
 end
@@ -21,4 +25,17 @@ end
 osl_dockercompose 'services' do
   directory '/var/lib/compose'
   config_files %w(docker-service1.yml docker-service2.yml)
+end
+
+osl_dockercompose 'oneshot' do
+  directory '/var/lib/compose'
+  config_files %w(docker-oneshot.yml)
+end
+
+# Simulate the docker_prune_containers cron reaping the exited one-shot
+# container. With enforce_idempotency the second converge then proves
+# osl_dockercompose[oneshot] still sees the project as running without it.
+execute 'prune exited oneshot container' do
+  command 'docker rm oneshot-migrate-1'
+  only_if 'docker ps -a --filter name=^oneshot-migrate-1$ --filter status=exited --format "{{.Names}}" | grep -q .'
 end

--- a/test/integration/inspec/controls/osl_dockercompose_spec.rb
+++ b/test/integration/inspec/controls/osl_dockercompose_spec.rb
@@ -26,4 +26,20 @@ control 'osl_dockercompose' do
     its('labels') { should include 'com.docker.compose.project=services' }
     its('labels') { should include 'com.docker.compose.service=hello_world2' }
   end
+
+  describe docker_container 'oneshot-hello_world-1' do
+    it { should exist }
+    it { should be_running }
+    its('image') { should eq 'alpine' }
+    its('command') { should eq '/bin/sleep 1d' }
+    its('labels') { should include 'com.docker.compose.project=oneshot' }
+    its('labels') { should include 'com.docker.compose.service=hello_world' }
+  end
+
+  # The exited migrate container was reaped after the first converge; if the
+  # running check miscounted the one-shot, the second converge would have
+  # re-run `up` and recreated it.
+  describe docker_container 'oneshot-migrate-1' do
+    it { should_not exist }
+  end
 end

--- a/test/integration/inspec/inspec.yml
+++ b/test/integration/inspec/inspec.yml
@@ -1,4 +1,7 @@
 name: osl-docker
+depends:
+  - name: inspec-docker-resources
+    gem: inspec-docker-resources
 inputs:
   - name: docker_env
     value: ''


### PR DESCRIPTION
## Summary

- `osl_dockercompose_running?` now filters out services with `restart: "no"` (e.g. a migration gate) when deciding whether a compose project is running. These services are expected to exit, and their stopped containers get reaped by the `docker_prune_containers` cron, so counting them made the check return false forever and re-ran `compose up` on every converge. `up --wait` already enforces their success through `depends_on` conditions.
- Switches the definition lookup from `docker compose config --services` to `config --format json`, since the plain service list doesn't expose restart policies.
- Adds unit coverage for the new behavior: exited one-shot, pruned one-shot, a stopped long-running service alongside a one-shot, an all-one-shot project, and that non-`"no"` restart policies still count.
- Adds an end-to-end kitchen test: a new `oneshot` compose project with a migration-gate service (`depends_on: service_completed_successfully`), plus a resource simulating the prune cron removing the exited container. With `enforce_idempotency` the second converge proves the guard still sees the project as running, and InSpec asserts the reaped one-shot container is not recreated.
- Declares the `inspec-docker-resources` gem in the InSpec profile, required for `docker_container` on InSpec 7.

## Test plan

- `chef exec rspec` (29 examples, 0 failures)
- `cookstyle` clean
- `kitchen test osl-dockercompose-almalinux-9` exercises the oneshot project across both converges

🤖 Generated with [Claude Code](https://claude.com/claude-code)